### PR TITLE
Update updating-noridocs skill to use sync-noridocs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nori-ai",
-  "version": "14.3.9",
+  "version": "14.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nori-ai",
-      "version": "14.3.9",
+      "version": "14.4.0",
       "dependencies": {
         "ajv": "^8.17.1",
         "firebase": "^12.3.0",

--- a/src/installer/features/profiles/config/_mixins/_docs/skills/updating-noridocs/SKILL.md
+++ b/src/installer/features/profiles/config/_mixins/_docs/skills/updating-noridocs/SKILL.md
@@ -48,13 +48,13 @@ Task(subagent_type: nori-change-documenter)
 - [ ] Review the diffs to ensure updates are accurate
 - [ ] Verify updates focus on system architecture, not minutiae
 
-### Step 4: Modify Remote docs.md Files
+### Step 4: Sync Remote docs.md Files
 
-- Check if the 'write-noridocs' skill exists at `~/.claude/skills/write-noridocs/SKILL.md`.
+- Check if the 'sync-noridocs' skill exists at `~/.claude/skills/sync-noridocs/SKILL.md`.
   - If it does not exist, skip this step.
-- Ask the user if they want to update remote docs.md files.
+- Ask the user if they want to sync all docs.md files to the remote server.
   - If the user declines, skip this step.
-- For each docs.md file you created, read the `~/.claude/skills/write-noridocs/SKILL.md` and follow instructions to write noridocs to the remote server.
+- Read and follow `~/.claude/skills/sync-noridocs/SKILL.md` to sync all noridocs to the remote server.
 
 ## Noridocs Format
 

--- a/src/installer/features/profiles/config/_mixins/_docs/subagents/nori-change-documenter.md
+++ b/src/installer/features/profiles/config/_mixins/_docs/subagents/nori-change-documenter.md
@@ -36,13 +36,13 @@ model: inherit
 - DO NOT evaluate if the logic is correct or optimal
 - DO NOT identify potential bugs or issues
 
-# Step 4: Modify Remote docs.md Files
+# Step 4: Sync Remote docs.md Files
 
-- Check if the 'write-noridocs' skill exists at `~/.claude/skills/write-noridocs/SKILL.md`.
+- Check if the 'sync-noridocs' skill exists at `~/.claude/skills/sync-noridocs/SKILL.md`.
   - If it does not exist, skip this step.
-- Ask the user if they want to update remote docs.md files.
+- Ask the user if they want to sync all docs.md files to the remote server.
   - If the user declines, skip this step.
-- For each docs.md file you created, read the `~/.claude/skills/write-noridocs/SKILL.md` and follow instructions to write noridocs to the remote server.
+- Read and follow `~/.claude/skills/sync-noridocs/SKILL.md` to sync all noridocs to the remote server.
 
 </required>
 

--- a/src/installer/features/profiles/config/_mixins/_docs/subagents/nori-initial-documenter.md
+++ b/src/installer/features/profiles/config/_mixins/_docs/subagents/nori-initial-documenter.md
@@ -36,13 +36,13 @@ model: inherit
 - DO NOT evaluate if the logic is correct or optimal
 - DO NOT identify potential bugs or issues
 
-# Step 4: Modify Remote docs.md Files
+# Step 4: Sync Remote docs.md Files
 
-- Check if the 'write-noridocs' skill exists at `~/.claude/skills/write-noridocs/SKILL.md`.
+- Check if the 'sync-noridocs' skill exists at `~/.claude/skills/sync-noridocs/SKILL.md`.
   - If it does not exist, skip this step.
-- Ask the user if they want to update remote docs.md files.
+- Ask the user if they want to sync all docs.md files to the remote server.
   - If the user declines, skip this step.
-- For each docs.md file you created, read the `~/.claude/skills/write-noridocs/SKILL.md` and follow instructions to write noridocs to the remote server.
+- Read and follow `~/.claude/skills/sync-noridocs/SKILL.md` to sync all noridocs to the remote server.
 
 </required>
 

--- a/src/installer/features/profiles/docs.md
+++ b/src/installer/features/profiles/docs.md
@@ -51,7 +51,7 @@ The profiles loader executes FIRST in both interactive and non-interactive insta
 **Mixin Categories**: Mixins use a two-tier naming convention: `{category}` for base features and `{category}-{tier}` for tier-specific features:
 
 - `_base`: Core infrastructure (using-skills, web-search-researcher, nori-debug/info/switch-profile commands)
-- `_docs`: Documentation workflows - free tier (updating-noridocs skill, nori-initial-documenter/nori-change-documenter subagents, initialize-noridocs command)
+- `_docs`: Documentation workflows - free tier (updating-noridocs skill, nori-initial-documenter/nori-change-documenter subagents, initialize-noridocs command). All documentation workflows follow a consistent pattern: update local docs.md files, then sync to remote server using sync-noridocs skill in a single bulk operation.
 - `_docs-paid`: Documentation workflows - paid tier (paid-write-noridoc, paid-read-noridoc, paid-list-noridocs, paid-sync-noridocs skills, sync-noridocs slash command)
 - `_swe`: Software engineering - free tier (12 skills like TDD/debugging/git-worktrees/building-ui-ux, 3 codebase-analysis subagents)
 - `_swe-paid`: Software engineering - paid tier (reserved for future paid SWE features)


### PR DESCRIPTION
## Summary
🤖 Generated with [Nori](https://www.npmjs.com/package/nori-ai)

- Updated Step 4 in three documentation workflow files (`updating-noridocs/SKILL.md`, `nori-change-documenter.md`, `nori-initial-documenter.md`) to use `sync-noridocs` instead of `write-noridoc`
- This reduces permission prompts from N (one per file) to 1 (single bulk operation)
- Improves UX by syncing all Git-tracked docs.md files to the remote server at once

## Test Plan
- [x] All 264 tests pass
- [x] Build completes successfully
- [x] Documentation updated in profiles/docs.md

Share Nori with your team: https://www.npmjs.com/package/nori-ai