### PR TITLE
refactor: Rebrand Nori Agent Brain to Nori Profiles

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -4,7 +4,7 @@ Path: @/plugin
 
 ### Overview
 
-Claude Code plugin package providing comprehensive integration with the Nori Agent Brain system through a directory-based profile system. Each profile is a complete, self-contained configuration with its own CLAUDE.md instructions, skills, subagents, and slash commands. The installer CLI manages profile installation and switching, while backend API tools enable paid tier knowledge management features.
+Claude Code plugin package providing comprehensive integration with the Nori Profiles system through a directory-based profile system. Each profile is a complete, self-contained configuration with its own CLAUDE.md instructions, skills, subagents, and slash commands. The installer CLI manages profile installation and switching, while backend API tools enable paid tier knowledge management features.
 
 ### How it fits into the larger codebase
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nori-ai",
-  "version": "14.4.0",
+  "version": "15.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nori-ai",
-      "version": "14.4.0",
+      "version": "15.0.0",
       "dependencies": {
         "ajv": "^8.17.1",
         "firebase": "^12.3.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "plugin",
     "context engineering"
   ],
-  "description": "Nori Agent Brain plugin for Claude Code",
+  "description": "Nori Profiles plugin for Claude Code",
   "type": "module",
   "bin": {
     "nori-ai": "./build/src/installer/cli.js"

--- a/src/api/docs.md
+++ b/src/api/docs.md
@@ -4,7 +4,7 @@ Path: @/plugin/src/api
 
 ### Overview
 
-Client API for communicating with the Nori Agent Brain backend server, providing typed interfaces for artifacts (including repository-scoped artifacts), queries, conversation operations, analytics (report generation and event tracking), noridocs management (with repository filtering), prompt analysis, webhook management, and heartbeat monitoring.
+Client API for communicating with the Nori Profiles backend server, providing typed interfaces for artifacts (including repository-scoped artifacts), queries, conversation operations, analytics (report generation and event tracking), noridocs management (with repository filtering), prompt analysis, webhook management, and heartbeat monitoring.
 
 ### How it fits into the larger codebase
 

--- a/src/installer/cli.ts
+++ b/src/installer/cli.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /**
- * Nori Agent Brain CLI Router
+ * Nori Profiles CLI Router
  *
  * Routes commands to the appropriate installer/uninstaller.
  */
@@ -23,8 +23,8 @@ const showHelp = (): void => {
   console.log("Usage: nori-ai [command] [options]");
   console.log("");
   console.log("Commands:");
-  console.log("  install              Install Nori Agent Brain (default)");
-  console.log("  uninstall            Uninstall Nori Agent Brain");
+  console.log("  install              Install Nori Profiles (default)");
+  console.log("  uninstall            Uninstall Nori Profiles");
   console.log(
     "  check                Validate Nori installation and configuration",
   );
@@ -51,7 +51,7 @@ const checkMain = async (args?: {
   const { installDir } = args || {};
 
   console.log("");
-  info({ message: "Running Nori Agent Brain validation checks..." });
+  info({ message: "Running Nori Profiles validation checks..." });
   console.log("");
 
   let hasErrors = false;

--- a/src/installer/config.ts
+++ b/src/installer/config.ts
@@ -1,5 +1,5 @@
 /**
- * Configuration management for Nori Agent Brain MCP installer
+ * Configuration management for Nori Profiles installer
  * Functional library for loading and managing disk-based configuration
  */
 

--- a/src/installer/docs.md
+++ b/src/installer/docs.md
@@ -4,7 +4,7 @@ Path: @/plugin/src/installer
 
 ### Overview
 
-CLI installer for Nori Agent Brain that prompts for configuration, installs features into Claude Code, manages credentials, and tracks installation analytics via Google Analytics, supporting both free (local-only) and paid (backend-integrated) installation modes with directory-based profile system.
+CLI installer for Nori Profiles that prompts for configuration, installs features into Claude Code, manages credentials, and tracks installation analytics via Google Analytics, supporting both free (local-only) and paid (backend-integrated) installation modes with directory-based profile system.
 
 ### How it fits into the larger codebase
 

--- a/src/installer/features/hooks/config/autoupdate.ts
+++ b/src/installer/features/hooks/config/autoupdate.ts
@@ -152,7 +152,7 @@ const main = async (): Promise<void> => {
 
     // Notify user via additionalContext
     logToClaudeSession({
-      message: `🔄 Nori Agent Brain update available: v${installedVersion} → v${latestVersion}. Installing in background...`,
+      message: `🔄 Nori Profiles update available: v${installedVersion} → v${latestVersion}. Installing in background...`,
     });
   } catch (err) {
     // Silent failure - don't interrupt session startup

--- a/src/installer/features/hooks/config/summarize-notification.ts
+++ b/src/installer/features/hooks/config/summarize-notification.ts
@@ -5,7 +5,7 @@
  *
  * This script is called by Claude Code hooks on SessionEnd event.
  * It outputs a synchronous message to inform the user that the transcript
- * is being saved to Nori Agent Brain (while the async summarize hook runs in background).
+ * is being saved to Nori Profiles (while the async summarize hook runs in background).
  */
 
 import { loadDiskConfig } from "@/installer/config.js";

--- a/src/installer/features/hooks/config/summarize.ts
+++ b/src/installer/features/hooks/config/summarize.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /**
- * Hook handler for summarizing conversations and storing them in Nori Agent Brain
+ * Hook handler for summarizing conversations and storing them in Nori Profiles
  *
  * This script is called by Claude Code hooks on SessionEnd and PreCompact events.
  * It summarizes the conversation context and stores it using the backend API.

--- a/src/installer/features/hooks/loader.ts
+++ b/src/installer/features/hooks/loader.ts
@@ -65,11 +65,11 @@ const summarizeNotificationHook: HookInterface = {
 };
 
 /**
- * Summarize hook - memorizes conversations to Nori Agent Brain (async)
+ * Summarize hook - memorizes conversations to Nori Profiles (async)
  */
 const summarizeHook: HookInterface = {
   name: "summarize",
-  description: "Memorize conversations to Nori Agent Brain",
+  description: "Memorize conversations to Nori Profiles",
   install: async () => {
     const scriptPath = path.join(HOOKS_CONFIG_DIR, "summarize.js");
     return [
@@ -80,7 +80,7 @@ const summarizeHook: HookInterface = {
           {
             type: "command",
             command: `node ${scriptPath} SessionEnd`,
-            description: "Memorize session summary to Nori Agent Brain",
+            description: "Memorize session summary to Nori Profiles",
           },
         ],
       },
@@ -92,7 +92,7 @@ const summarizeHook: HookInterface = {
             type: "command",
             command: `node ${scriptPath} PreCompact`,
             description:
-              "Memorize conversation before context compaction to Nori Agent Brain",
+              "Memorize conversation before context compaction to Nori Profiles",
           },
         ],
       },
@@ -105,7 +105,7 @@ const summarizeHook: HookInterface = {
  */
 const autoupdateHook: HookInterface = {
   name: "autoupdate",
-  description: "Check for Nori Agent Brain updates",
+  description: "Check for Nori Profiles updates",
   install: async () => {
     const scriptPath = path.join(HOOKS_CONFIG_DIR, "autoupdate.js");
     return [
@@ -116,7 +116,7 @@ const autoupdateHook: HookInterface = {
           {
             type: "command",
             command: `node ${scriptPath}`,
-            description: "Check for Nori Agent Brain updates on session start",
+            description: "Check for Nori Profiles updates on session start",
           },
         ],
       },

--- a/src/installer/features/profiles/config/_mixins/_base/slashcommands/nori-debug.md
+++ b/src/installer/features/profiles/config/_mixins/_base/slashcommands/nori-debug.md
@@ -1,10 +1,10 @@
 ---
-description: Validate Nori Agent Brain installation and configuration
+description: Validate Nori Profiles installation and configuration
 ---
 
 !`npx nori-ai check`
 
-This validates the Nori Agent Brain installation:
+This validates the Nori Profiles installation:
 
 - Config file structure and credentials
 - Server authentication (paid mode only)
@@ -12,7 +12,6 @@ This validates the Nori Agent Brain installation:
 - Subagent files in ~/.claude/agents/
 - Slash command files in ~/.claude/commands/
 - CLAUDE.md managed block
-- MCP server registration (paid mode only)
 
 ## Troubleshooting
 

--- a/src/installer/features/profiles/config/_mixins/_base/slashcommands/nori-info.md
+++ b/src/installer/features/profiles/config/_mixins/_base/slashcommands/nori-info.md
@@ -1,8 +1,8 @@
 ---
-description: Display information about Nori Agent Brain features and capabilities
+description: Display information about Nori Profiles features and capabilities
 ---
 
-Please read the following information about Nori Agent Brain and provide a clear, concise summary to me. After your summary, state: "I loaded the nori documentation. You can ask me for more help about how to use nori if you would like."
+Please read the following information about Nori Profiles and provide a clear, concise summary to me. After your summary, state: "I loaded the nori documentation. You can ask me for more help about how to use nori if you would like."
 
 Suggest helpful follow-up questions like:
 
@@ -14,7 +14,7 @@ Suggest helpful follow-up questions like:
 
 ---
 
-# Nori Agent Brain Documentation
+# Nori Profiles Documentation
 
 Nori enhances Claude Code with better context management, specialized workflows, and team collaboration features.
 

--- a/src/installer/features/profiles/config/_mixins/_paid/slashcommands/nori-toggle-session-transcripts.md
+++ b/src/installer/features/profiles/config/_mixins/_paid/slashcommands/nori-toggle-session-transcripts.md
@@ -3,7 +3,7 @@ description: Toggle session transcript summarization on or off
 allowed-tools: Read(~/nori-config.json:*), Write(~/nori-config.json:*)
 ---
 
-Toggle whether session transcripts are sent to Nori Agent Brain for summarization and storage.
+Toggle whether session transcripts are sent to Nori Profiles for summarization and storage.
 
 ## Your Task
 

--- a/src/installer/features/profiles/config/_mixins/_paid/subagents/nori-knowledge-researcher.md
+++ b/src/installer/features/profiles/config/_mixins/_paid/subagents/nori-knowledge-researcher.md
@@ -1,11 +1,11 @@
 ---
 name: nori-knowledge-researcher
-description: Research specialist for querying the agent-brain knowledge base to find relevant context and information. Executes focused, iterative research with clear stopping criteria.
+description: Research specialist for querying the Nori knowledge base to find relevant context and information. Executes focused, iterative research with clear stopping criteria.
 tools: Read, Grep, Glob, Bash, WebFetch, WebSearch
 model: inherit
 ---
 
-You are a knowledge research specialist with access to the agent-brain knowledge base. Your goal is to perform focused, efficient research to find relevant context and information.
+You are a knowledge research specialist with access to the Nori knowledge base. Your goal is to perform focused, efficient research to find relevant context and information.
 
 # Research Budget
 
@@ -15,7 +15,7 @@ Track your tool usage and prioritize the most impactful queries. Stop when you h
 
 # Your Capabilities
 
-- **Recall**: Query the agent-brain knowledge base. This contains all information stored across the team, and is a critical first entry point. You should always do a Recall query first. Read `~/.claude/skills/recall/SKILL.md` for usage instructions, then execute via Bash.
+- **Recall**: Query the Nori knowledge base. This contains all information stored across the team, and is a critical first entry point. You should always do a Recall query first. Read `~/.claude/skills/recall/SKILL.md` for usage instructions, then execute via Bash.
 - **Memorize**: Save insights. Read `~/.claude/skills/memorize/SKILL.md` for usage instructions, then execute via Bash.
 - **Read, Grep, Glob**: Search and read files in the codebase. Always check for docs.md files in relevant folders - these contain curated documentation about that code area.
 - **Bash**: Execute commands to explore the environment and run paid skills. Use Read/Grep/Glob instead of Bash for file lookups.

--- a/src/installer/features/statusline/config/nori-statusline.sh
+++ b/src/installer/features/statusline/config/nori-statusline.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Nori Agent Brain Status Line
+# Nori Profiles Status Line
 # Displays git branch, session cost, token usage, and Nori branding
 
 # Read JSON context from stdin

--- a/src/installer/install.ts
+++ b/src/installer/install.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /**
- * Nori Agent Brain MCP Tool Installer
+ * Nori Profiles Installer
  *
  * Pipeline-style installer that prompts for configuration and executes feature loaders.
  */

--- a/src/installer/profiles.ts
+++ b/src/installer/profiles.ts
@@ -1,5 +1,5 @@
 /**
- * Profile management for Nori Agent Brain
+ * Profile management for Nori Profiles
  * Handles profile listing, loading, and switching
  */
 

--- a/src/installer/uninstall.ts
+++ b/src/installer/uninstall.ts
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 
 /**
- * Nori Agent Brain MCP Tool Uninstaller
+ * Nori Profiles Uninstaller
  *
- * Removes all features installed by the Nori Agent Brain installer.
+ * Removes all features installed by the Nori Profiles installer.
  */
 
 import * as fs from "fs/promises";
@@ -39,10 +39,10 @@ const promptForUninstall = async (args?: {
 } | null> => {
   const { installDir } = args || {};
 
-  info({ message: "Nori Agent Brain Uninstaller" });
+  info({ message: "Nori Profiles Uninstaller" });
   console.log();
   warn({
-    message: "This will remove all Nori Agent Brain features from your system.",
+    message: "This will remove all Nori Profiles features from your system.",
   });
   console.log();
 
@@ -66,7 +66,6 @@ const promptForUninstall = async (args?: {
 
   info({ message: "The following will be removed:" });
   if (existingDiskConfig?.auth) {
-    info({ message: "  - MCP server (agent-brain)" });
     info({ message: "  - nori-knowledge-researcher subagent" });
     info({ message: "  - Automatic memorization hooks" });
   }
@@ -297,7 +296,7 @@ export const main = async (args?: {
         "======================================================================",
     });
     success({
-      message: "       Nori Agent Brain Uninstallation Complete!              ",
+      message: "       Nori Profiles Uninstallation Complete!              ",
     });
     success({
       message:

--- a/src/installer/version.ts
+++ b/src/installer/version.ts
@@ -1,5 +1,5 @@
 /**
- * Version tracking utilities for Nori Agent Brain installer
+ * Version tracking utilities for Nori Profiles installer
  *
  * Manages version tracking to ensure proper uninstallation of previous versions
  * before installing new versions.


### PR DESCRIPTION
## Summary

- Replace all "Nori Agent Brain" branding with "Nori Profiles" across the codebase
- Update CLI messages, hook descriptions, slash commands, and documentation
- Remove stale reference to non-existent MCP server (agent-brain) from uninstaller

## Test Plan

- [x] All 314 tests pass
- [x] Lint and format pass
- [x] No remaining "Nori Agent Brain" strings in src/
- [ ] CI passes on PR

🤖 Generated with [Nori](https://www.npmjs.com/package/nori-ai)

Share Nori with your team: https://www.npmjs.com/package/nori-ai