### PR TITLE
feat: Make .nori-config.json local to installation directory

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,7 +3,52 @@
   "permissions": {
     "additionalDirectories": [
       "/home/amol/code/nori/nori-plugin/.worktrees/configurable-install-dir/.claude/profiles",
-      "/home/amol/code/nori/nori-plugin/.worktrees/configurable-install-dir/.claude/skills"
+      "/home/amol/code/nori/nori-plugin/.worktrees/configurable-install-dir/.claude/skills",
+      "/home/amol/code/nori/nori-plugin/.worktrees/local-nori-config/.claude/profiles",
+      "/home/amol/code/nori/nori-plugin/.worktrees/local-nori-config/.claude/skills"
     ]
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node /home/amol/code/nori/nori-plugin/.worktrees/local-nori-config/build/src/installer/features/hooks/config/autoupdate.js",
+            "description": "Check for Nori Profiles updates on session start"
+          }
+        ]
+      }
+    ],
+    "Notification": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/home/amol/code/nori/nori-plugin/.worktrees/local-nori-config/build/src/installer/features/hooks/config/notify-hook.sh",
+            "description": "Send desktop notification when Claude needs input"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node /home/amol/code/nori/nori-plugin/.worktrees/local-nori-config/build/src/installer/features/hooks/config/quick-switch.js",
+            "description": "Intercept /switch-nori-profile for instant profile switching"
+          }
+        ]
+      }
+    ]
+  },
+  "statusLine": {
+    "type": "command",
+    "command": "/home/amol/code/nori/nori-plugin/.worktrees/local-nori-config/build/src/installer/features/statusline/config/nori-statusline.sh",
+    "padding": 0
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nori-ai",
-  "version": "15.0.0",
+  "version": "15.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nori-ai",
-      "version": "15.0.0",
+      "version": "15.1.0",
       "dependencies": {
         "ajv": "^8.17.1",
         "firebase": "^12.3.0",

--- a/src/api/base.test.ts
+++ b/src/api/base.test.ts
@@ -1,63 +1,43 @@
-import { existsSync, readFileSync } from "fs";
+import * as fs from "fs/promises";
+import * as os from "os";
+import * as path from "path";
 
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 import { ConfigManager } from "./base.js";
 
-vi.mock("fs");
-
 describe("ConfigManager", () => {
-  const mockExistsSync = vi.mocked(existsSync);
-  const mockReadFileSync = vi.mocked(readFileSync);
+  let tempDir: string;
+  let originalCwd: string;
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    // Create temp directory for testing
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "config-manager-test-"));
+    originalCwd = process.cwd();
+    process.chdir(tempDir);
     vi.clearAllMocks();
   });
 
-  it("should return empty object when config file does not exist", () => {
-    mockExistsSync.mockReturnValue(false);
+  afterEach(async () => {
+    // Restore original CWD
+    process.chdir(originalCwd);
 
+    // Clean up temp directory
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("should return empty object when config file does not exist in CWD", () => {
+    // No config file in tempDir (CWD)
     const result = ConfigManager.loadConfig();
 
     expect(result).toEqual({});
   });
 
-  // Race condition scenarios: these test cases cover situations where
-  // analytics code calls loadConfig() before/during config file creation
-  it("should return empty object when config file is empty (race condition)", () => {
-    // Simulates reading the file after creation but before write completes
-    mockExistsSync.mockReturnValue(true);
-    mockReadFileSync.mockReturnValue("");
-
-    const result = ConfigManager.loadConfig();
-
-    expect(result).toEqual({});
-  });
-
-  it("should return empty object when config file contains whitespace only (race condition)", () => {
-    // Simulates partial file write during race condition
-    mockExistsSync.mockReturnValue(true);
-    mockReadFileSync.mockReturnValue("   \n  \t  ");
-
-    const result = ConfigManager.loadConfig();
-
-    expect(result).toEqual({});
-  });
-
-  // Unexpected error scenarios: truly malformed content should still be caught
-  it("should return empty object when config file contains invalid JSON", () => {
-    mockExistsSync.mockReturnValue(true);
-    mockReadFileSync.mockReturnValue("{invalid json}");
-
-    const result = ConfigManager.loadConfig();
-
-    expect(result).toEqual({});
-  });
-
-  // Happy path: normal config loading
-  it("should parse and return valid config", () => {
-    mockExistsSync.mockReturnValue(true);
-    mockReadFileSync.mockReturnValue(
+  it("should load config from .nori-config.json in CWD", async () => {
+    // Create config file in CWD
+    const configPath = path.join(tempDir, ".nori-config.json");
+    await fs.writeFile(
+      configPath,
       JSON.stringify({
         username: "test@example.com",
         password: "test123",
@@ -71,6 +51,76 @@ describe("ConfigManager", () => {
       username: "test@example.com",
       password: "test123",
       organizationUrl: "https://example.com",
+    });
+  });
+
+  // Race condition scenarios: these test cases cover situations where
+  // analytics code calls loadConfig() before/during config file creation
+  it("should return empty object when config file is empty (race condition)", async () => {
+    // Simulates reading the file after creation but before write completes
+    const configPath = path.join(tempDir, ".nori-config.json");
+    await fs.writeFile(configPath, "");
+
+    const result = ConfigManager.loadConfig();
+
+    expect(result).toEqual({});
+  });
+
+  it("should return empty object when config file contains whitespace only (race condition)", async () => {
+    // Simulates partial file write during race condition
+    const configPath = path.join(tempDir, ".nori-config.json");
+    await fs.writeFile(configPath, "   \n  \t  ");
+
+    const result = ConfigManager.loadConfig();
+
+    expect(result).toEqual({});
+  });
+
+  // Unexpected error scenarios: truly malformed content should still be caught
+  it("should return empty object when config file contains invalid JSON", async () => {
+    const configPath = path.join(tempDir, ".nori-config.json");
+    await fs.writeFile(configPath, "{invalid json}");
+
+    const result = ConfigManager.loadConfig();
+
+    expect(result).toEqual({});
+  });
+
+  describe("isConfigured", () => {
+    it("should return false when config file does not exist", () => {
+      const result = ConfigManager.isConfigured();
+
+      expect(result).toBe(false);
+    });
+
+    it("should return false when credentials are missing", async () => {
+      const configPath = path.join(tempDir, ".nori-config.json");
+      await fs.writeFile(
+        configPath,
+        JSON.stringify({
+          profile: { baseProfile: "senior-swe" },
+        }),
+      );
+
+      const result = ConfigManager.isConfigured();
+
+      expect(result).toBe(false);
+    });
+
+    it("should return true when all credentials are present", async () => {
+      const configPath = path.join(tempDir, ".nori-config.json");
+      await fs.writeFile(
+        configPath,
+        JSON.stringify({
+          username: "test@example.com",
+          password: "test123",
+          organizationUrl: "https://example.com",
+        }),
+      );
+
+      const result = ConfigManager.isConfigured();
+
+      expect(result).toBe(true);
     });
   });
 });

--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -1,5 +1,4 @@
 import { readFileSync, existsSync } from "fs";
-import { homedir } from "os";
 import { join } from "path";
 
 import { signInWithEmailAndPassword } from "firebase/auth";
@@ -14,12 +13,19 @@ export type NoriConfig = {
 };
 
 export class ConfigManager {
-  private static readonly CONFIG_PATH = join(homedir(), "nori-config.json");
+  /**
+   * Get the config path - uses CWD only (no fallback)
+   * @returns The path to .nori-config.json in CWD
+   */
+  private static getConfigPath = (): string => {
+    return join(process.cwd(), ".nori-config.json");
+  };
 
   static loadConfig = (): NoriConfig => {
     try {
-      if (existsSync(ConfigManager.CONFIG_PATH)) {
-        const content = readFileSync(ConfigManager.CONFIG_PATH, "utf8");
+      const configPath = ConfigManager.getConfigPath();
+      if (existsSync(configPath)) {
+        const content = readFileSync(configPath, "utf8");
 
         // RACE CONDITION HANDLING:
         // During fresh installation, trackEvent() is called fire-and-forget (not awaited)

--- a/src/installer/config.ts
+++ b/src/installer/config.ts
@@ -60,8 +60,30 @@ export const getConfigPath = (args?: {
     return path.join(installDir, ".nori-config.json");
   }
 
-  // Legacy behavior: use HOME directory with non-dotfile name
-  return path.join(process.env.HOME || "~", "nori-config.json");
+  // Default behavior: use HOME directory with dotfile name
+  return path.join(process.env.HOME || "~", ".nori-config.json");
+};
+
+/**
+ * Find the config file path by checking CWD only (no fallback)
+ * @param args - Configuration arguments
+ * @param args.cwd - Current working directory to check (defaults to process.cwd())
+ *
+ * @returns The path to .nori-config.json if found, null otherwise
+ */
+export const findConfigPath = async (args?: {
+  cwd?: string | null;
+}): Promise<string | null> => {
+  const { cwd } = args || {};
+  const targetDir = cwd || process.cwd();
+  const configPath = path.join(targetDir, ".nori-config.json");
+
+  try {
+    await fs.access(configPath);
+    return configPath;
+  } catch {
+    return null;
+  }
 };
 
 /**

--- a/src/installer/features/hooks/config/summarize.ts
+++ b/src/installer/features/hooks/config/summarize.ts
@@ -151,7 +151,7 @@ const summarizeConversation = async (args: {
   if (!ConfigManager.isConfigured()) {
     error({
       message:
-        "Nori hook: Not configured. Skipping memorization. Set credentials in ~/nori-config.json",
+        "Nori hook: Not configured. Skipping memorization. Set credentials in .nori-config.json",
     });
     return;
   }

--- a/src/installer/features/profiles/config/_mixins/_docs-paid/skills/paid-list-noridocs/script.ts
+++ b/src/installer/features/profiles/config/_mixins/_docs-paid/skills/paid-list-noridocs/script.ts
@@ -60,13 +60,16 @@ Description:
  * Main execution function
  */
 export const main = async (): Promise<void> => {
-  // 1. Check tier
-  const diskConfig = await loadDiskConfig();
+  // 1. Check tier - use CWD for config location
+  const cwd = process.cwd();
+  const diskConfig = await loadDiskConfig({ installDir: cwd });
   const config = generateConfig({ diskConfig });
 
   if (config.installType !== "paid") {
     console.error("Error: This feature requires a paid Nori subscription.");
-    console.error("Please configure your credentials in ~/nori-config.json");
+    console.error(
+      `Please configure your credentials in ${cwd}/.nori-config.json`,
+    );
     process.exit(1);
   }
 

--- a/src/installer/features/profiles/config/_mixins/_docs-paid/skills/paid-read-noridoc/script.test.ts
+++ b/src/installer/features/profiles/config/_mixins/_docs-paid/skills/paid-read-noridoc/script.test.ts
@@ -11,19 +11,21 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { main } from "./script.js";
 
 describe("paid-read-noridoc script", () => {
+  let tempDir: string;
   let tempConfigPath: string;
-  let originalHome: string | undefined;
+  let originalCwd: string;
   let originalArgv: Array<string>;
   let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
   let processExitSpy: ReturnType<typeof vi.spyOn>;
 
-  beforeEach(() => {
-    originalHome = process.env.HOME;
+  beforeEach(async () => {
+    originalCwd = process.cwd();
     originalArgv = process.argv;
 
-    const tempDir = path.join(os.tmpdir(), `read-noridoc-test-${Date.now()}`);
-    process.env.HOME = tempDir;
-    tempConfigPath = path.join(tempDir, "nori-config.json");
+    tempDir = path.join(os.tmpdir(), `read-noridoc-test-${Date.now()}`);
+    await fs.mkdir(tempDir, { recursive: true });
+    process.chdir(tempDir);
+    tempConfigPath = path.join(tempDir, ".nori-config.json");
 
     consoleErrorSpy = vi
       .spyOn(console, "error")
@@ -36,16 +38,14 @@ describe("paid-read-noridoc script", () => {
   });
 
   afterEach(async () => {
-    if (originalHome !== undefined) {
-      process.env.HOME = originalHome;
-    }
+    process.chdir(originalCwd);
     process.argv = originalArgv;
 
     consoleErrorSpy.mockRestore();
     processExitSpy.mockRestore();
 
     try {
-      await fs.rm(path.dirname(tempConfigPath), {
+      await fs.rm(tempDir, {
         recursive: true,
         force: true,
       });
@@ -66,7 +66,6 @@ describe("paid-read-noridoc script", () => {
     });
 
     it("should fail when config has no auth credentials", async () => {
-      await fs.mkdir(path.dirname(tempConfigPath), { recursive: true });
       await fs.writeFile(tempConfigPath, JSON.stringify({}));
 
       process.argv = ["node", "script.js", "--filePath=@/test"];
@@ -78,7 +77,6 @@ describe("paid-read-noridoc script", () => {
 
   describe("argument parsing", () => {
     it("should fail when --filePath is missing", async () => {
-      await fs.mkdir(path.dirname(tempConfigPath), { recursive: true });
       await fs.writeFile(
         tempConfigPath,
         JSON.stringify({
@@ -98,7 +96,6 @@ describe("paid-read-noridoc script", () => {
     });
 
     it("should show usage help when arguments are invalid", async () => {
-      await fs.mkdir(path.dirname(tempConfigPath), { recursive: true });
       await fs.writeFile(
         tempConfigPath,
         JSON.stringify({

--- a/src/installer/features/profiles/config/_mixins/_docs-paid/skills/paid-read-noridoc/script.ts
+++ b/src/installer/features/profiles/config/_mixins/_docs-paid/skills/paid-read-noridoc/script.ts
@@ -43,13 +43,16 @@ Description:
  * Main execution function
  */
 export const main = async (): Promise<void> => {
-  // 1. Check tier
-  const diskConfig = await loadDiskConfig();
+  // 1. Check tier - use CWD for config location
+  const cwd = process.cwd();
+  const diskConfig = await loadDiskConfig({ installDir: cwd });
   const config = generateConfig({ diskConfig });
 
   if (config.installType !== "paid") {
     console.error("Error: This feature requires a paid Nori subscription.");
-    console.error("Please configure your credentials in ~/nori-config.json");
+    console.error(
+      `Please configure your credentials in ${cwd}/.nori-config.json`,
+    );
     process.exit(1);
   }
 

--- a/src/installer/features/profiles/config/_mixins/_docs-paid/skills/paid-sync-noridocs/script.ts
+++ b/src/installer/features/profiles/config/_mixins/_docs-paid/skills/paid-sync-noridocs/script.ts
@@ -276,13 +276,16 @@ const syncFile = async (args: {
  * Main execution function
  */
 export const main = async (): Promise<void> => {
-  // 1. Check tier
-  const diskConfig = await loadDiskConfig();
+  // 1. Check tier - use CWD for config location
+  const cwd = process.cwd();
+  const diskConfig = await loadDiskConfig({ installDir: cwd });
   const config = generateConfig({ diskConfig });
 
   if (config.installType !== "paid") {
     console.error("Error: This feature requires a paid Nori subscription.");
-    console.error("Please configure your credentials in ~/nori-config.json");
+    console.error(
+      `Please configure your credentials in ${cwd}/.nori-config.json`,
+    );
     process.exit(1);
   }
 
@@ -295,7 +298,6 @@ export const main = async (): Promise<void> => {
   }
 
   const delay = (args.delay as number | null) ?? 500;
-  const cwd = process.cwd();
 
   // Auto-detect git remote URL if not provided
   const gitRepoUrl =

--- a/src/installer/features/profiles/config/_mixins/_docs-paid/skills/paid-write-noridoc/script.ts
+++ b/src/installer/features/profiles/config/_mixins/_docs-paid/skills/paid-write-noridoc/script.ts
@@ -57,13 +57,16 @@ Description:
  * Main execution function
  */
 export const main = async (): Promise<void> => {
-  // 1. Check tier
-  const diskConfig = await loadDiskConfig();
+  // 1. Check tier - use CWD for config location
+  const cwd = process.cwd();
+  const diskConfig = await loadDiskConfig({ installDir: cwd });
   const config = generateConfig({ diskConfig });
 
   if (config.installType !== "paid") {
     console.error("Error: This feature requires a paid Nori subscription.");
-    console.error("Please configure your credentials in ~/nori-config.json");
+    console.error(
+      `Please configure your credentials in ${cwd}/.nori-config.json`,
+    );
     process.exit(1);
   }
 

--- a/src/installer/features/profiles/config/_mixins/_paid/skills/paid-memorize/script.ts
+++ b/src/installer/features/profiles/config/_mixins/_paid/skills/paid-memorize/script.ts
@@ -78,13 +78,16 @@ ${name}
  * Main execution function
  */
 export const main = async (): Promise<void> => {
-  // 1. Check tier
-  const diskConfig = await loadDiskConfig();
+  // 1. Check tier - use CWD for config location
+  const cwd = process.cwd();
+  const diskConfig = await loadDiskConfig({ installDir: cwd });
   const config = generateConfig({ diskConfig });
 
   if (config.installType !== "paid") {
     console.error("Error: This feature requires a paid Nori subscription.");
-    console.error("Please configure your credentials in ~/nori-config.json");
+    console.error(
+      `Please configure your credentials in ${cwd}/.nori-config.json`,
+    );
     process.exit(1);
   }
 

--- a/src/installer/features/profiles/config/_mixins/_paid/skills/paid-prompt-analysis/script.ts
+++ b/src/installer/features/profiles/config/_mixins/_paid/skills/paid-prompt-analysis/script.ts
@@ -119,13 +119,16 @@ const formatFeedbackItem = (args: { item: FeedbackItem }): string => {
  * Main execution function
  */
 export const main = async (): Promise<void> => {
-  // 1. Check tier
-  const diskConfig = await loadDiskConfig();
+  // 1. Check tier - use CWD for config location
+  const cwd = process.cwd();
+  const diskConfig = await loadDiskConfig({ installDir: cwd });
   const config = generateConfig({ diskConfig });
 
   if (config.installType !== "paid") {
     console.error("Error: This feature requires a paid Nori subscription.");
-    console.error("Please configure your credentials in ~/nori-config.json");
+    console.error(
+      `Please configure your credentials in ${cwd}/.nori-config.json`,
+    );
     process.exit(1);
   }
 

--- a/src/installer/features/profiles/config/_mixins/_paid/skills/paid-recall/script.test.ts
+++ b/src/installer/features/profiles/config/_mixins/_paid/skills/paid-recall/script.test.ts
@@ -11,19 +11,21 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { main } from "./script.js";
 
 describe("paid-recall script", () => {
+  let tempDir: string;
   let tempConfigPath: string;
-  let originalHome: string | undefined;
+  let originalCwd: string;
   let originalArgv: Array<string>;
   let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
   let processExitSpy: ReturnType<typeof vi.spyOn>;
 
-  beforeEach(() => {
-    originalHome = process.env.HOME;
+  beforeEach(async () => {
+    originalCwd = process.cwd();
     originalArgv = process.argv;
 
-    const tempDir = path.join(os.tmpdir(), `recall-test-${Date.now()}`);
-    process.env.HOME = tempDir;
-    tempConfigPath = path.join(tempDir, "nori-config.json");
+    tempDir = path.join(os.tmpdir(), `recall-test-${Date.now()}`);
+    await fs.mkdir(tempDir, { recursive: true });
+    process.chdir(tempDir);
+    tempConfigPath = path.join(tempDir, ".nori-config.json");
 
     consoleErrorSpy = vi
       .spyOn(console, "error")
@@ -36,16 +38,14 @@ describe("paid-recall script", () => {
   });
 
   afterEach(async () => {
-    if (originalHome !== undefined) {
-      process.env.HOME = originalHome;
-    }
+    process.chdir(originalCwd);
     process.argv = originalArgv;
 
     consoleErrorSpy.mockRestore();
     processExitSpy.mockRestore();
 
     try {
-      await fs.rm(path.dirname(tempConfigPath), {
+      await fs.rm(tempDir, {
         recursive: true,
         force: true,
       });
@@ -66,7 +66,6 @@ describe("paid-recall script", () => {
     });
 
     it("should fail when config has no auth credentials", async () => {
-      await fs.mkdir(path.dirname(tempConfigPath), { recursive: true });
       await fs.writeFile(tempConfigPath, JSON.stringify({}));
 
       process.argv = ["node", "script.js", "--query=test"];
@@ -78,7 +77,6 @@ describe("paid-recall script", () => {
 
   describe("argument parsing", () => {
     it("should fail when --query is missing", async () => {
-      await fs.mkdir(path.dirname(tempConfigPath), { recursive: true });
       await fs.writeFile(
         tempConfigPath,
         JSON.stringify({
@@ -98,7 +96,6 @@ describe("paid-recall script", () => {
     });
 
     it("should show usage help when arguments are invalid", async () => {
-      await fs.mkdir(path.dirname(tempConfigPath), { recursive: true });
       await fs.writeFile(
         tempConfigPath,
         JSON.stringify({

--- a/src/installer/features/profiles/config/_mixins/_paid/skills/paid-recall/script.ts
+++ b/src/installer/features/profiles/config/_mixins/_paid/skills/paid-recall/script.ts
@@ -85,13 +85,16 @@ const formatArtifact = (args: {
  * Main execution function
  */
 export const main = async (): Promise<void> => {
-  // 1. Check tier
-  const diskConfig = await loadDiskConfig();
+  // 1. Check tier - use CWD for config location
+  const cwd = process.cwd();
+  const diskConfig = await loadDiskConfig({ installDir: cwd });
   const config = generateConfig({ diskConfig });
 
   if (config.installType !== "paid") {
     console.error("Error: This feature requires a paid Nori subscription.");
-    console.error("Please configure your credentials in ~/nori-config.json");
+    console.error(
+      `Please configure your credentials in ${cwd}/.nori-config.json`,
+    );
     process.exit(1);
   }
 

--- a/src/installer/features/statusline/config/nori-statusline.sh
+++ b/src/installer/features/statusline/config/nori-statusline.sh
@@ -6,12 +6,21 @@
 # Read JSON context from stdin
 INPUT=$(cat)
 
-# === CONFIG TIER ENRICHMENT ===
-# Get config tier from ~/nori-config.json
-CONFIG_TIER="unknown"
-CONFIG_FILE="$HOME/nori-config.json"
+# Extract current working directory from JSON first (needed for config lookup)
+CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
 
-if [ -f "$CONFIG_FILE" ]; then
+# === CONFIG TIER ENRICHMENT ===
+# Get config tier from .nori-config.json in CWD (no fallback to HOME)
+CONFIG_TIER="unknown"
+
+# Use CWD config only
+if [ -n "$CWD" ]; then
+    CONFIG_FILE="$CWD/.nori-config.json"
+else
+    CONFIG_FILE=""
+fi
+
+if [ -n "$CONFIG_FILE" ] && [ -f "$CONFIG_FILE" ]; then
     # Check if auth credentials exist in config
     HAS_AUTH=$(jq -r 'select(.username != null and .password != null and .organizationUrl != null) | "true"' "$CONFIG_FILE" 2>/dev/null)
 
@@ -46,9 +55,6 @@ CYAN='\033[0;36m'
 YELLOW='\033[0;33m'
 DIM_WHITE='\033[2;37m'
 NC='\033[0m' # No Color
-
-# Extract current working directory from JSON
-CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
 
 # Get git branch
 BRANCH=""

--- a/src/installer/features/statusline/loader.test.ts
+++ b/src/installer/features/statusline/loader.test.ts
@@ -140,14 +140,14 @@ describe("statuslineLoader", () => {
   });
 
   describe("statusline script", () => {
-    it("should include profile name in output when nori-config.json exists", async () => {
+    it("should include profile name in output when .nori-config.json exists", async () => {
       const config: Config = { installType: "free" };
 
       // Install statusline
       await statuslineLoader.run({ config });
 
-      // Create mock nori-config.json with profile in temp directory
-      const noriConfigPath = path.join(tempDir, "nori-config.json");
+      // Create mock .nori-config.json with profile in temp directory (CWD)
+      const noriConfigPath = path.join(tempDir, ".nori-config.json");
       const noriConfigContent = JSON.stringify({
         profile: { baseProfile: "amol" },
       });
@@ -179,19 +179,19 @@ describe("statuslineLoader", () => {
         // Verify output contains profile name
         expect(output).toContain("Profile: amol");
       } finally {
-        // Clean up nori-config.json
+        // Clean up .nori-config.json
         await fs.rm(noriConfigPath, { force: true });
       }
     });
 
-    it("should not show profile when nori-config.json does not exist", async () => {
+    it("should not show profile when .nori-config.json does not exist", async () => {
       const config: Config = { installType: "free" };
 
       // Install statusline
       await statuslineLoader.run({ config });
 
-      // Ensure nori-config.json does not exist in temp directory
-      const noriConfigPath = path.join(tempDir, "nori-config.json");
+      // Ensure .nori-config.json does not exist in temp directory
+      const noriConfigPath = path.join(tempDir, ".nori-config.json");
       await fs.rm(noriConfigPath, { force: true });
 
       try {

--- a/src/installer/install.ts
+++ b/src/installer/install.ts
@@ -312,8 +312,8 @@ export const main = async (args?: {
 
   try {
     // Check if there's an existing installation to clean up
-    if (!skipUninstall && hasExistingInstallation()) {
-      const previousVersion = getInstalledVersion();
+    if (!skipUninstall && hasExistingInstallation({ installDir })) {
+      const previousVersion = getInstalledVersion({ installDir });
       info({
         message: `Cleaning up previous installation (v${previousVersion})...`,
       });
@@ -472,7 +472,7 @@ export const main = async (args?: {
     // Save installed version
     const finalVersion = getCurrentPackageVersion();
     if (finalVersion) {
-      saveInstalledVersion({ version: finalVersion });
+      saveInstalledVersion({ version: finalVersion, installDir });
     }
 
     // Delete install-in-progress marker on successful completion

--- a/src/installer/uninstall.ts
+++ b/src/installer/uninstall.ts
@@ -157,10 +157,14 @@ const removeConfigFile = async (args?: {
 }): Promise<void> => {
   const { installDir } = args || {};
   const configPath = getConfigPath({ installDir });
-  const versionPath = path.join(
-    process.env.HOME || "~",
-    ".nori-installed-version",
-  );
+
+  // Version file is in installDir if provided, otherwise HOME
+  let versionPath: string;
+  if (installDir != null && installDir !== "") {
+    versionPath = path.join(installDir, ".nori-installed-version");
+  } else {
+    versionPath = path.join(process.env.HOME || "~", ".nori-installed-version");
+  }
 
   info({ message: "Removing Nori configuration files..." });
 

--- a/src/installer/version.ts
+++ b/src/installer/version.ts
@@ -15,23 +15,38 @@ const DEFAULT_VERSION = "12.1.0";
 
 /**
  * Get the path to the version file
+ * @param args - Configuration arguments
+ * @param args.installDir - Custom installation directory (optional)
+ *
  * @returns The absolute path to .nori-installed-version
  */
-const getVersionFilePath = (): string => {
+const getVersionFilePath = (args?: { installDir?: string | null }): string => {
+  const { installDir } = args || {};
+
+  if (installDir != null && installDir !== "") {
+    return join(installDir, ".nori-installed-version");
+  }
+
   return join(process.env.HOME || "~", ".nori-installed-version");
 };
 
 /**
  * Check if there's an existing installation
  * An installation exists if:
- * - Version file exists at ~/.nori-installed-version
- * - OR config file exists at ~/nori-config.json
+ * - Version file exists at {installDir}/.nori-installed-version
+ * - OR config file exists at {installDir}/.nori-config.json
+ *
+ * @param args - Configuration arguments
+ * @param args.installDir - Custom installation directory (optional)
  *
  * @returns true if an installation exists, false otherwise
  */
-export const hasExistingInstallation = (): boolean => {
-  const versionFileExists = existsSync(getVersionFilePath());
-  const configFileExists = existsSync(getConfigPath());
+export const hasExistingInstallation = (args?: {
+  installDir?: string | null;
+}): boolean => {
+  const { installDir } = args || {};
+  const versionFileExists = existsSync(getVersionFilePath({ installDir }));
+  const configFileExists = existsSync(getConfigPath({ installDir }));
   return versionFileExists || configFileExists;
 };
 
@@ -55,13 +70,22 @@ export const getCurrentPackageVersion = (): string | null => {
 };
 
 /**
- * Get the installed version from ~/.nori-installed-version
+ * Get the installed version from {installDir}/.nori-installed-version
  * Defaults to 12.1.0 if file does not exist (assumes existing installations are 12.1.0)
+ * @param args - Configuration arguments
+ * @param args.installDir - Custom installation directory (optional)
+ *
  * @returns The installed version string
  */
-export const getInstalledVersion = (): string => {
+export const getInstalledVersion = (args?: {
+  installDir?: string | null;
+}): string => {
+  const { installDir } = args || {};
   try {
-    const version = readFileSync(getVersionFilePath(), "utf-8").trim();
+    const version = readFileSync(
+      getVersionFilePath({ installDir }),
+      "utf-8",
+    ).trim();
     if (version) {
       return version;
     }
@@ -73,11 +97,15 @@ export const getInstalledVersion = (): string => {
 };
 
 /**
- * Save the installed version to ~/.nori-installed-version
+ * Save the installed version to {installDir}/.nori-installed-version
  * @param args - Configuration arguments
  * @param args.version - Version to save
+ * @param args.installDir - Custom installation directory (optional)
  */
-export const saveInstalledVersion = (args: { version: string }): void => {
-  const { version } = args;
-  writeFileSync(getVersionFilePath(), version, "utf-8");
+export const saveInstalledVersion = (args: {
+  version: string;
+  installDir?: string | null;
+}): void => {
+  const { version, installDir } = args;
+  writeFileSync(getVersionFilePath({ installDir }), version, "utf-8");
 };


### PR DESCRIPTION
## Summary
🤖 Generated with [Nori](https://www.npmjs.com/package/nori-ai)

- Changed config file location from `~/nori-config.json` to `{installDir}/.nori-config.json`
- All config access now uses CWD-only detection (no fallback to HOME directory)
- Updated ConfigManager, skill scripts, status line, and version tracking to use local config path

## Test Plan
- [x] All 334 tests pass
- [x] Format and lint pass
- [ ] Manual test: Run `cd /some/project && npx nori-ai install` and verify `.nori-config.json` is created in `/some/project/`
- [ ] Manual test: Verify skill scripts find config in CWD
- [ ] Manual test: Verify uninstall removes local config file

Share Nori with your team: https://www.npmjs.com/package/nori-ai