### PR TITLE
Add /nori-install-location slash command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nori-ai",
-  "version": "16.0.5",
+  "version": "16.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nori-ai",
-      "version": "16.0.5",
+      "version": "16.0.7",
       "dependencies": {
         "@types/semver": "^7.7.1",
         "ajv": "^8.17.1",

--- a/src/installer/cli.ts
+++ b/src/installer/cli.ts
@@ -20,7 +20,7 @@ import { error, success, info } from "@/installer/logger.js";
 import { switchProfile } from "@/installer/profiles.js";
 import { registerUninstallCommand } from "@/installer/uninstall.js";
 import { getCurrentPackageVersion } from "@/installer/version.js";
-import { normalizeInstallDir } from "@/utils/path.js";
+import { normalizeInstallDir, getInstallDirs } from "@/utils/path.js";
 
 /**
  * Run validation checks on Nori installation
@@ -170,6 +170,41 @@ const registerSwitchProfileCommand = (args: { program: Command }): void => {
     });
 };
 
+/**
+ * Register the 'install-location' command with commander
+ * @param args - Configuration arguments
+ * @param args.program - Commander program instance
+ */
+const registerInstallLocationCommand = (args: { program: Command }): void => {
+  const { program } = args;
+
+  program
+    .command("install-location")
+    .description("Display Nori installation directories")
+    .action(async () => {
+      const currentDir = process.cwd();
+      const installDirs = getInstallDirs({ currentDir });
+
+      if (installDirs.length === 0) {
+        error({
+          message:
+            "No Nori installations found in current directory or parent directories",
+        });
+        process.exit(1);
+      }
+
+      console.log("");
+      info({ message: "Nori installation directories:" });
+      console.log("");
+
+      for (const dir of installDirs) {
+        success({ message: `  ${dir}` });
+      }
+
+      console.log("");
+    });
+};
+
 const program = new Command();
 const version = getCurrentPackageVersion() || "unknown";
 
@@ -190,6 +225,7 @@ Examples:
   $ nori-ai install --install-dir ~/my-dir
   $ nori-ai uninstall
   $ nori-ai check
+  $ nori-ai install-location
   $ nori-ai switch-profile senior-swe
   $ nori-ai --non-interactive install
 `,
@@ -200,6 +236,7 @@ registerInstallCommand({ program });
 registerUninstallCommand({ program });
 registerCheckCommand({ program });
 registerSwitchProfileCommand({ program });
+registerInstallLocationCommand({ program });
 
 program.parse(process.argv);
 

--- a/src/installer/features/profiles/config/_mixins/_base/slashcommands/nori-info.md
+++ b/src/installer/features/profiles/config/_mixins/_base/slashcommands/nori-info.md
@@ -203,6 +203,7 @@ Custom commands available in Claude Code.
 
 - `/nori-info` - Display this information (you're using it now!)
 - `/nori-debug` - Validate Nori installation (`npx nori-ai check`)
+- `/nori-install-location` - Display Nori installation directories
 - `/nori-switch-profile` - Switch between profiles interactively
 - `/nori-init-docs` - Generate documentation files throughout codebase
 

--- a/src/installer/features/profiles/config/_mixins/_base/slashcommands/nori-install-location.md
+++ b/src/installer/features/profiles/config/_mixins/_base/slashcommands/nori-install-location.md
@@ -1,0 +1,7 @@
+---
+description: Display the current Nori installation directory
+---
+
+!`npx nori-ai install-location`
+
+This command displays all Nori installation directories found by searching upward from your current working directory.

--- a/src/installer/features/profiles/slashcommands/loader.test.ts
+++ b/src/installer/features/profiles/slashcommands/loader.test.ts
@@ -116,6 +116,29 @@ describe("slashCommandsLoader", () => {
       const secondFiles = await fs.readdir(commandsDir);
       expect(secondFiles.length).toBeGreaterThan(0);
     });
+
+    it("should install nori-install-location.md slash command", async () => {
+      const config: Config = { installType: "free", installDir: tempDir };
+
+      await slashCommandsLoader.install({ config });
+
+      // Verify nori-install-location.md exists
+      const installLocationPath = path.join(
+        commandsDir,
+        "nori-install-location.md",
+      );
+      const exists = await fs
+        .access(installLocationPath)
+        .then(() => true)
+        .catch(() => false);
+
+      expect(exists).toBe(true);
+
+      // Verify file has content
+      const content = await fs.readFile(installLocationPath, "utf-8");
+      expect(content).toContain("description:");
+      expect(content.length).toBeGreaterThan(0);
+    });
   });
 
   describe("uninstall", () => {


### PR DESCRIPTION
## Summary
🤖 Generated with [Nori](https://www.npmjs.com/package/nori-ai)

- Added `/nori-install-location` slash command that displays Nori installation directories
- Runs `npx nori-ai install-location` CLI command which uses `getInstallDirs()` to search upward from current directory
- Updated `/nori-info` documentation to include the new command
- Added CLI help example for the new command

## Test Plan
- [x] Added integration test verifying slash command file is installed correctly
- [x] All 389 tests pass
- [x] Linting and formatting pass

Share Nori with your team: https://www.npmjs.com/package/nori-ai