### PR TITLE
Fix CI build failures by adding path alias verification

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,11 +23,14 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # Explicit build step before lint/test to ensure build artifacts are fresh
+      # Note: npm ci runs 'prepare' which also builds, but we rebuild here to
+      # guarantee a clean build before tests run
+      - name: Build package
+        run: npm run build
+
       - name: Run linter
         run: npm run lint
 
       - name: Run tests
         run: npm test
-
-      - name: Build package
-        run: npm run build

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nori-ai",
-  "version": "16.0.8",
+  "version": "16.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nori-ai",
-      "version": "16.0.8",
+      "version": "16.0.9",
       "dependencies": {
         "@types/semver": "^7.7.1",
         "ajv": "^8.17.1",

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -42,7 +42,18 @@ echo ""
 # Converts TypeScript path aliases (@/* -> src/*) to relative paths
 # Example: '@/api/index.js' becomes '../../../../../api/index.js'
 echo -e "${BLUE}[2/6] Resolving path aliases...${NC}"
-tsc-alias
+tsc-alias --verbose
+
+# Verify no @/ imports remain in production JS files (not test files)
+# This catches cases where tsc-alias silently fails to resolve paths
+UNRESOLVED=$(grep -r "from ['\"]@/" build/src --include="*.js" | grep -v "\.test\.js" | grep -v "vi\.mock" || true)
+if [ -n "$UNRESOLVED" ]; then
+  echo -e "${RED}ERROR: Unresolved @/ imports found after tsc-alias:${NC}"
+  echo "$UNRESOLVED"
+  echo -e "${RED}This indicates tsc-alias failed to resolve path aliases.${NC}"
+  exit 1
+fi
+
 echo -e "${GREEN}✓ Path aliases resolved${NC}"
 echo ""
 


### PR DESCRIPTION
## Summary

- Added verification step to build.sh that checks for unresolved `@/` imports
  after tsc-alias runs. This catches cases where tsc-alias silently fails.
- Reordered CI workflow to run explicit build step before lint/tests,
  ensuring fresh build artifacts are used.

## Root cause

The `prepare` script (run during `npm ci`) was producing a broken build where
`tsc-alias` didn't resolve `@/` path aliases. Tests then ran against this
broken build and failed with "Cannot find package '@/api'" errors.

## Changes

- `scripts/build.sh`: Added `--verbose` flag to tsc-alias and verification
  that checks no `@/` imports remain in production JS files
- `.github/workflows/ci.yaml`: Moved build step before lint/tests

## Test plan

- [x] All 393 tests pass locally
- [x] Lint passes
- [ ] CI passes on this PR