### PR TITLE
Update install prompt to explain Nori Watchtower

### DIFF
--- a/src/cli/commands/install/install.ts
+++ b/src/cli/commands/install/install.ts
@@ -196,13 +196,13 @@ export const generatePromptConfig = async (args: {
   // Prompt for credentials
   info({
     message: wrapText({
-      text: "Do you have Nori credentials? You should have gotten an email from Josh or Amol if you are on the Nori paid plan. Type in your email address to set up Nori Paid, or hit enter to skip.",
+      text: "Nori Watchtower is our backend service that enables shared knowledge features - search and recall past solutions across your team, save learnings for future sessions, and server-side documentation with versioning. If you have Watchtower credentials (you should have received them from Josh or Amol), enter your email to enable these features. Otherwise, press enter to continue with local-only features.",
     }),
   });
   console.log();
 
   const username = await promptUser({
-    prompt: "Email address (paid tier) or hit enter to skip (free tier): ",
+    prompt: "Email address (Watchtower) or hit enter to skip: ",
   });
 
   let auth: {


### PR DESCRIPTION
## Summary
🤖 Generated with [Nori](https://www.npmjs.com/package/nori-ai)

- Update the install step credentials prompt to explain what Nori Watchtower is (shared knowledge features - recall/memorize, server-side docs with versioning)
- Change the prompt text from asking about "paid account" to describing Watchtower's features
- Keep the reference to Josh/Amol as the source of credentials

## Test Plan
- [x] All 628 tests pass
- [x] Format and lint pass
- [ ] Manually test installation flow to verify the new text displays correctly

Share Nori with your team: https://www.npmjs.com/package/nori-ai