### PR TITLE
feat: add Cursor slash commands loader

### DIFF
--- a/src/cli/commands/docs.md
+++ b/src/cli/commands/docs.md
@@ -65,7 +65,11 @@ The `install/` directory contains command-specific utilities:
 
 The `install-location/` command was extracted from inline definition in cli.ts to follow the same pattern as other commands.
 
-The `install-cursor/` command installs Nori profiles to Cursor IDE (`~/.cursor/profiles/`). It uses CursorLoaderRegistry instead of LoaderRegistry and executes Cursor-specific loaders that write to Cursor paths. The command always installs to the user's home directory (os.homedir()) and does not support the `--install-dir` option.
+The `install-cursor/` command installs Nori components to Cursor IDE. It uses CursorLoaderRegistry instead of LoaderRegistry and executes Cursor-specific loaders that write to Cursor paths:
+- Profiles installed to `~/.cursor/profiles/`
+- Slash commands installed to `~/.cursor/commands/`
+
+The command always installs to the user's home directory (os.homedir()) and does not support the `--install-dir` option.
 
 Tests within each command directory use the same temp directory isolation pattern as other tests in the codebase, passing `installDir` explicitly to functions rather than mocking `process.env.HOME`.
 

--- a/src/cli/commands/install-cursor/installCursor.test.ts
+++ b/src/cli/commands/install-cursor/installCursor.test.ts
@@ -22,6 +22,7 @@ vi.mock("@/cli/env.js", () => ({
   getCursorDir: () => mockCursorDir,
   getCursorSettingsFile: () => path.join(mockCursorDir, "settings.json"),
   getCursorProfilesDir: () => path.join(mockCursorDir, "profiles"),
+  getCursorCommandsDir: () => path.join(mockCursorDir, "commands"),
   MCP_ROOT: "/mock/mcp/root",
 }));
 

--- a/src/cli/env.ts
+++ b/src/cli/env.ts
@@ -151,6 +151,17 @@ export const getCursorProfilesDir = (args: { installDir: string }): string => {
 };
 
 /**
+ * Get the Cursor commands directory path
+ * @param args - Configuration arguments
+ * @param args.installDir - Installation directory
+ *
+ * @returns Absolute path to the commands directory
+ */
+export const getCursorCommandsDir = (args: { installDir: string }): string => {
+  return path.join(getCursorDir(args), "commands");
+};
+
+/**
  * Get the Cursor home directory path (always ~/.cursor)
  * This is where Cursor stores user-level configuration.
  *

--- a/src/cli/features/cursor/cursorLoaderRegistry.test.ts
+++ b/src/cli/features/cursor/cursorLoaderRegistry.test.ts
@@ -51,6 +51,16 @@ describe("CursorLoaderRegistry", () => {
       expect(hasProfilesLoader).toBe(true);
     });
 
+    it("should include cursorSlashCommandsLoader", () => {
+      const registry = CursorLoaderRegistry.getInstance();
+      const loaders = registry.getAll();
+
+      const hasSlashCommandsLoader = loaders.some(
+        (loader) => loader.name === "cursor-slashcommands",
+      );
+      expect(hasSlashCommandsLoader).toBe(true);
+    });
+
     it("should return loaders with required interface properties", () => {
       const registry = CursorLoaderRegistry.getInstance();
       const loaders = registry.getAll();

--- a/src/cli/features/cursor/cursorLoaderRegistry.ts
+++ b/src/cli/features/cursor/cursorLoaderRegistry.ts
@@ -4,6 +4,7 @@
  */
 
 import { cursorProfilesLoader } from "@/cli/features/cursor/profiles/loader.js";
+import { cursorSlashCommandsLoader } from "@/cli/features/cursor/slashcommands/loader.js";
 
 import type { Loader } from "@/cli/features/loaderRegistry.js";
 
@@ -18,9 +19,8 @@ export class CursorLoaderRegistry {
     this.loaders = new Map();
 
     // Register all Cursor loaders
-    // For now, only profiles loader is registered
-    // Additional loaders can be added here as needed
     this.loaders.set(cursorProfilesLoader.name, cursorProfilesLoader);
+    this.loaders.set(cursorSlashCommandsLoader.name, cursorSlashCommandsLoader);
   }
 
   /**

--- a/src/cli/features/cursor/docs.md
+++ b/src/cli/features/cursor/docs.md
@@ -4,7 +4,7 @@ Path: @/src/cli/features/cursor
 
 ### Overview
 
-Feature loader registry and implementations for installing Nori components into Cursor IDE. Uses a separate CursorLoaderRegistry singleton that mirrors the main LoaderRegistry pattern but writes to `~/.cursor/` instead of `~/.claude/`. Currently implements profiles installation, with infrastructure to add more Cursor-specific loaders.
+Feature loader registry and implementations for installing Nori components into Cursor IDE. Uses a separate CursorLoaderRegistry singleton that mirrors the main LoaderRegistry pattern but writes to `~/.cursor/` instead of `~/.claude/`. Implements profiles and slash commands installation.
 
 ### How it fits into the larger codebase
 
@@ -21,18 +21,18 @@ This directory provides Cursor IDE support parallel to the main Claude Code inst
     ~/.claude/                   ~/.cursor/
     - profiles/                  - profiles/
     - settings.json              - settings.json
-    - skills/                    (future loaders)
+    - skills/                    - commands/
     - commands/
     - hooks/
 ```
 
 The `install-cursor` command (@/src/cli/commands/install-cursor/installCursor.ts) uses CursorLoaderRegistry to execute all registered Cursor loaders. The cursor profiles loader reuses the same profile template source files from @/src/cli/features/profiles/config/ but writes to `~/.cursor/profiles/` via Cursor-specific path helpers in @/src/cli/env.ts.
 
-Cursor environment path helpers (getCursorDir, getCursorSettingsFile, getCursorProfilesDir, getCursorHomeDir, getCursorHomeSettingsFile) in @/src/cli/env.ts parallel the existing Claude path helpers.
+Cursor environment path helpers (getCursorDir, getCursorSettingsFile, getCursorProfilesDir, getCursorCommandsDir, getCursorHomeDir, getCursorHomeSettingsFile) in @/src/cli/env.ts parallel the existing Claude path helpers.
 
 ### Core Implementation
 
-**CursorLoaderRegistry** (cursorLoaderRegistry.ts): Singleton registry managing Cursor feature loaders. Implements the same interface as LoaderRegistry with getAll() and getAllReversed() methods. Currently registers only the cursorProfilesLoader.
+**CursorLoaderRegistry** (cursorLoaderRegistry.ts): Singleton registry managing Cursor feature loaders. Implements the same interface as LoaderRegistry with getAll() and getAllReversed() methods. Registers cursorProfilesLoader and cursorSlashCommandsLoader.
 
 **Cursor Profiles Loader** (profiles/loader.ts): Installs profile templates to `~/.cursor/profiles/`. Key behaviors:
 - Reuses profile templates from @/src/cli/features/profiles/config/ (no separate Cursor templates)
@@ -40,13 +40,20 @@ Cursor environment path helpers (getCursorDir, getCursorSettingsFile, getCursorP
 - Configures permissions by updating `~/.cursor/settings.json` with additionalDirectories
 - Validates installation by checking required profiles and permissions configuration
 
+**Cursor Slash Commands Loader** (slashcommands/loader.ts): Installs slash command markdown files to `~/.cursor/commands/`. Key behaviors:
+- Reuses command markdown files from @/src/cli/features/slashcommands/config/ (shared with Claude loader)
+- Applies template path substitution with `getCursorDir` so paths resolve to `~/.cursor/` instead of `~/.claude/`
+- Validates installation by checking all expected commands are present in the commands directory
+
 ### Things to Know
 
-The cursor profiles loader implements the same `Loader` interface from @/src/cli/features/loaderRegistry.ts, enabling consistent run/uninstall/validate behavior. The loader:
+Both loaders implement the same `Loader` interface from @/src/cli/features/loaderRegistry.ts, enabling consistent run/uninstall/validate behavior. The profiles loader:
 - Injects conditional paid mixins based on config.auth presence (isPaidUser check)
 - Composes profiles from mixins in alphabetical order
 - Updates Cursor settings.json with profiles directory in permissions.additionalDirectories
 - During uninstall, only removes builtin profiles (identified by `"builtin": true` in profile.json), preserving user-created profiles
+
+The slash commands loader reads markdown files from the shared config directory at @/src/cli/features/slashcommands/config/, applies template substitution using `getCursorDir` (not `getClaudeDir`), and writes to `~/.cursor/commands/`. During uninstall, removes only commands that match the source config directory contents, and cleans up the directory if empty.
 
 The CursorLoaderRegistry is intentionally separate from LoaderRegistry to allow independent loader management. Future Cursor features (hooks, statusline, skills, etc.) would add their own loaders registered in this registry.
 

--- a/src/cli/features/cursor/slashcommands/loader.test.ts
+++ b/src/cli/features/cursor/slashcommands/loader.test.ts
@@ -1,0 +1,269 @@
+/**
+ * Tests for Cursor slash commands feature loader
+ * Verifies install, uninstall, and validate operations for Cursor slash commands
+ */
+
+import * as fs from "fs/promises";
+import * as os from "os";
+import * as path from "path";
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+import type { Config } from "@/cli/config.js";
+
+// Mock the env module to use temp directories
+let mockCursorDir: string;
+let mockCursorCommandsDir: string;
+
+vi.mock("@/cli/env.js", () => ({
+  getCursorDir: () => mockCursorDir,
+  getCursorSettingsFile: () => path.join(mockCursorDir, "settings.json"),
+  getCursorHomeDir: () => mockCursorDir,
+  getCursorHomeSettingsFile: () => path.join(mockCursorDir, "settings.json"),
+  getCursorCommandsDir: () => mockCursorCommandsDir,
+  getCursorProfilesDir: () => path.join(mockCursorDir, "profiles"),
+  // Also mock Claude paths for any shared code
+  getClaudeDir: () => mockCursorDir,
+  getClaudeSettingsFile: () => path.join(mockCursorDir, "settings.json"),
+  getClaudeHomeDir: () => mockCursorDir,
+  getClaudeHomeSettingsFile: () => path.join(mockCursorDir, "settings.json"),
+  getClaudeAgentsDir: () => path.join(mockCursorDir, "agents"),
+  getClaudeCommandsDir: () => mockCursorCommandsDir,
+  getClaudeMdFile: () => path.join(mockCursorDir, "CLAUDE.md"),
+  getClaudeSkillsDir: () => path.join(mockCursorDir, "skills"),
+  getClaudeProfilesDir: () => path.join(mockCursorDir, "profiles"),
+  MCP_ROOT: "/mock/mcp/root",
+}));
+
+// Import loader after mocking env
+import { cursorSlashCommandsLoader } from "./loader.js";
+
+describe("cursorSlashCommandsLoader", () => {
+  let tempDir: string;
+  let cursorDir: string;
+  let commandsDir: string;
+
+  beforeEach(async () => {
+    // Create temp directory for testing
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "cursor-slashcmd-test-"));
+    cursorDir = path.join(tempDir, ".cursor");
+    commandsDir = path.join(cursorDir, "commands");
+
+    // Set mock paths
+    mockCursorDir = cursorDir;
+    mockCursorCommandsDir = commandsDir;
+
+    // Create directories
+    await fs.mkdir(cursorDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    // Clean up temp directory
+    await fs.rm(tempDir, { recursive: true, force: true });
+
+    // Clear all mocks
+    vi.clearAllMocks();
+  });
+
+  describe("loader metadata", () => {
+    it("should have name 'cursor-slashcommands'", () => {
+      expect(cursorSlashCommandsLoader.name).toBe("cursor-slashcommands");
+    });
+
+    it("should have a description", () => {
+      expect(cursorSlashCommandsLoader.description).toBeDefined();
+      expect(cursorSlashCommandsLoader.description.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("run (install)", () => {
+    it("should create commands directory and copy slash command files", async () => {
+      const config: Config = { installDir: tempDir };
+
+      await cursorSlashCommandsLoader.run({ config });
+
+      // Verify commands directory exists
+      const exists = await fs
+        .access(commandsDir)
+        .then(() => true)
+        .catch(() => false);
+
+      expect(exists).toBe(true);
+
+      // Verify slash command files were copied
+      const files = await fs.readdir(commandsDir);
+      const mdFiles = files.filter((f) => f.endsWith(".md"));
+      expect(mdFiles.length).toBeGreaterThan(0);
+    });
+
+    it("should install all global slash commands from config directory", async () => {
+      const config: Config = { installDir: tempDir };
+
+      await cursorSlashCommandsLoader.run({ config });
+
+      const files = await fs.readdir(commandsDir);
+      const mdFiles = files.filter((f) => f.endsWith(".md"));
+
+      // Should install at least the known essential commands
+      expect(mdFiles.length).toBeGreaterThan(5);
+      expect(mdFiles).toContain("nori-debug.md");
+      expect(mdFiles).toContain("nori-switch-profile.md");
+    });
+
+    it("should install nori-debug.md slash command", async () => {
+      const config: Config = { installDir: tempDir };
+
+      await cursorSlashCommandsLoader.run({ config });
+
+      const debugPath = path.join(commandsDir, "nori-debug.md");
+      const exists = await fs
+        .access(debugPath)
+        .then(() => true)
+        .catch(() => false);
+
+      expect(exists).toBe(true);
+
+      const content = await fs.readFile(debugPath, "utf-8");
+      expect(content).toContain("description:");
+    });
+
+    it("should apply template substitution to slash command files", async () => {
+      const config: Config = { installDir: tempDir };
+
+      await cursorSlashCommandsLoader.run({ config });
+
+      // Check nori-create-profile.md which uses {{profiles_dir}} placeholder
+      const createProfilePath = path.join(
+        commandsDir,
+        "nori-create-profile.md",
+      );
+      const content = await fs.readFile(createProfilePath, "utf-8");
+
+      // Should NOT contain template placeholders
+      expect(content).not.toContain("{{profiles_dir}}");
+      expect(content).not.toContain("{{skills_dir}}");
+    });
+
+    it("should handle reinstallation (update scenario)", async () => {
+      const config: Config = { installDir: tempDir };
+
+      // First installation
+      await cursorSlashCommandsLoader.run({ config });
+
+      const firstFiles = await fs.readdir(commandsDir);
+      expect(firstFiles.length).toBeGreaterThan(0);
+
+      // Second installation (update)
+      await cursorSlashCommandsLoader.run({ config });
+
+      const secondFiles = await fs.readdir(commandsDir);
+      expect(secondFiles.length).toBeGreaterThan(0);
+      expect(secondFiles.length).toBe(firstFiles.length);
+    });
+  });
+
+  describe("uninstall", () => {
+    it("should remove all Nori slash command files", async () => {
+      const config: Config = { installDir: tempDir };
+
+      // Install first
+      await cursorSlashCommandsLoader.run({ config });
+
+      // Get list of installed files
+      const installedFiles = await fs.readdir(commandsDir);
+      const installedMdFiles = installedFiles.filter((f) => f.endsWith(".md"));
+      expect(installedMdFiles.length).toBeGreaterThan(0);
+
+      // Uninstall
+      await cursorSlashCommandsLoader.uninstall({ config });
+
+      // Verify Nori slash command files are removed
+      const exists = await fs
+        .access(commandsDir)
+        .then(() => true)
+        .catch(() => false);
+
+      if (exists) {
+        const remainingFiles = await fs.readdir(commandsDir);
+        // All installed Nori slash commands should be removed
+        for (const cmd of installedMdFiles) {
+          expect(remainingFiles).not.toContain(cmd);
+        }
+      }
+    });
+
+    it("should handle missing commands directory gracefully", async () => {
+      const config: Config = { installDir: tempDir };
+
+      // Uninstall without installing first
+      await expect(
+        cursorSlashCommandsLoader.uninstall({ config }),
+      ).resolves.not.toThrow();
+    });
+
+    it("should preserve non-Nori slash command files", async () => {
+      const config: Config = { installDir: tempDir };
+
+      // Install Nori commands
+      await cursorSlashCommandsLoader.run({ config });
+
+      // Add a custom non-Nori slash command
+      const customCommandPath = path.join(commandsDir, "my-custom-command.md");
+      await fs.writeFile(customCommandPath, "# Custom command\nThis is custom");
+
+      // Uninstall Nori commands
+      await cursorSlashCommandsLoader.uninstall({ config });
+
+      // Verify custom command is preserved
+      const customExists = await fs
+        .access(customCommandPath)
+        .then(() => true)
+        .catch(() => false);
+
+      expect(customExists).toBe(true);
+    });
+  });
+
+  describe("validate", () => {
+    it("should return valid when all commands are installed", async () => {
+      const config: Config = { installDir: tempDir };
+
+      // Install first
+      await cursorSlashCommandsLoader.run({ config });
+
+      // Validate
+      const result = await cursorSlashCommandsLoader.validate!({ config });
+
+      expect(result.valid).toBe(true);
+    });
+
+    it("should return invalid when commands directory does not exist", async () => {
+      const config: Config = { installDir: tempDir };
+
+      // Don't install - commands directory doesn't exist
+
+      // Validate
+      const result = await cursorSlashCommandsLoader.validate!({ config });
+
+      expect(result.valid).toBe(false);
+      expect(result.errors).toBeDefined();
+    });
+
+    it("should return invalid when some commands are missing", async () => {
+      const config: Config = { installDir: tempDir };
+
+      // Install first
+      await cursorSlashCommandsLoader.run({ config });
+
+      // Remove one command
+      await fs.unlink(path.join(commandsDir, "nori-debug.md"));
+
+      // Validate
+      const result = await cursorSlashCommandsLoader.validate!({ config });
+
+      expect(result.valid).toBe(false);
+      expect(result.errors).toBeDefined();
+      expect(result.message).toContain("missing");
+    });
+  });
+});

--- a/src/cli/features/cursor/slashcommands/loader.ts
+++ b/src/cli/features/cursor/slashcommands/loader.ts
@@ -1,0 +1,221 @@
+/**
+ * Cursor slash commands feature loader
+ * Registers Nori slash commands with Cursor IDE
+ * These commands are installed to ~/.cursor/commands/
+ */
+
+import * as fs from "fs/promises";
+import * as path from "path";
+import { fileURLToPath } from "url";
+
+import { getCursorCommandsDir, getCursorDir } from "@/cli/env.js";
+import { success, info } from "@/cli/logger.js";
+import { substituteTemplatePaths } from "@/utils/template.js";
+
+import type { Config } from "@/cli/config.js";
+import type {
+  Loader,
+  ValidationResult,
+} from "@/cli/features/loaderRegistry.js";
+
+// Get directory of this loader file
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Config directory containing slash command markdown files (shared with Claude loader)
+const CONFIG_DIR = path.join(__dirname, "../../slashcommands/config");
+
+/**
+ * Get list of slash commands by reading the config directory
+ * @returns Array of command names (without .md extension)
+ */
+const getSlashCommands = async (): Promise<Array<string>> => {
+  const files = await fs.readdir(CONFIG_DIR);
+  return files
+    .filter((f) => f.endsWith(".md"))
+    .map((f) => f.replace(/\.md$/, ""))
+    .sort();
+};
+
+/**
+ * Register all slash commands for Cursor
+ * @param args - Configuration arguments
+ * @param args.config - Runtime configuration
+ */
+const registerSlashCommands = async (args: {
+  config: Config;
+}): Promise<void> => {
+  const { config } = args;
+  info({ message: "Registering Nori slash commands for Cursor..." });
+
+  const cursorCommandsDir = getCursorCommandsDir({
+    installDir: config.installDir,
+  });
+
+  // Create commands directory if it doesn't exist
+  await fs.mkdir(cursorCommandsDir, { recursive: true });
+
+  const commands = await getSlashCommands();
+  let registeredCount = 0;
+
+  for (const commandName of commands) {
+    const fileName = `${commandName}.md`;
+    const commandSrc = path.join(CONFIG_DIR, fileName);
+    const commandDest = path.join(cursorCommandsDir, fileName);
+
+    // Read content and apply template substitution
+    const content = await fs.readFile(commandSrc, "utf-8");
+    const cursorDir = getCursorDir({ installDir: config.installDir });
+    const substituted = substituteTemplatePaths({
+      content,
+      installDir: cursorDir,
+    });
+    await fs.writeFile(commandDest, substituted);
+    success({ message: `✓ /${commandName} slash command registered` });
+    registeredCount++;
+  }
+
+  if (registeredCount > 0) {
+    success({
+      message: `Successfully registered ${registeredCount} slash command${
+        registeredCount === 1 ? "" : "s"
+      } for Cursor`,
+    });
+  }
+};
+
+/**
+ * Unregister all slash commands from Cursor
+ * @param args - Configuration arguments
+ * @param args.config - Runtime configuration
+ */
+const unregisterSlashCommands = async (args: {
+  config: Config;
+}): Promise<void> => {
+  const { config } = args;
+  info({ message: "Removing Nori slash commands from Cursor..." });
+
+  let removedCount = 0;
+
+  const cursorCommandsDir = getCursorCommandsDir({
+    installDir: config.installDir,
+  });
+
+  const commands = await getSlashCommands();
+
+  for (const commandName of commands) {
+    const fileName = `${commandName}.md`;
+    const commandPath = path.join(cursorCommandsDir, fileName);
+
+    try {
+      await fs.access(commandPath);
+      await fs.unlink(commandPath);
+      success({ message: `✓ /${commandName} slash command removed` });
+      removedCount++;
+    } catch {
+      // Command not found, which is fine
+    }
+  }
+
+  if (removedCount > 0) {
+    success({
+      message: `Successfully removed ${removedCount} slash command${
+        removedCount === 1 ? "" : "s"
+      } from Cursor`,
+    });
+  }
+
+  // Remove commands directory if empty
+  try {
+    const files = await fs.readdir(cursorCommandsDir);
+    if (files.length === 0) {
+      await fs.rmdir(cursorCommandsDir);
+      success({ message: `✓ Removed empty directory: ${cursorCommandsDir}` });
+    }
+  } catch {
+    // Directory doesn't exist or couldn't be removed, which is fine
+  }
+};
+
+/**
+ * Validate Cursor slash commands installation
+ * @param args - Configuration arguments
+ * @param args.config - Runtime configuration
+ *
+ * @returns Validation result
+ */
+const validate = async (args: {
+  config: Config;
+}): Promise<ValidationResult> => {
+  const { config } = args;
+  const errors: Array<string> = [];
+
+  const cursorCommandsDir = getCursorCommandsDir({
+    installDir: config.installDir,
+  });
+
+  // Check if commands directory exists
+  try {
+    await fs.access(cursorCommandsDir);
+  } catch {
+    errors.push(`Commands directory not found at ${cursorCommandsDir}`);
+    errors.push(
+      'Run "nori-ai install-cursor" to create the commands directory',
+    );
+    return {
+      valid: false,
+      message: "Commands directory not found",
+      errors,
+    };
+  }
+
+  // Check if all expected slash commands are present
+  const commands = await getSlashCommands();
+  const missingCommands: Array<string> = [];
+
+  for (const commandName of commands) {
+    const fileName = `${commandName}.md`;
+    const commandPath = path.join(cursorCommandsDir, fileName);
+
+    try {
+      await fs.access(commandPath);
+    } catch {
+      missingCommands.push(commandName);
+    }
+  }
+
+  if (missingCommands.length > 0) {
+    errors.push(
+      `Missing ${missingCommands.length} slash command(s): ${missingCommands.join(", ")}`,
+    );
+    errors.push('Run "nori-ai install-cursor" to register missing commands');
+    return {
+      valid: false,
+      message: "Some Cursor slash commands are missing",
+      errors,
+    };
+  }
+
+  return {
+    valid: true,
+    message: `All ${commands.length} Cursor slash commands are properly installed`,
+    errors: null,
+  };
+};
+
+/**
+ * Cursor slash commands feature loader
+ */
+export const cursorSlashCommandsLoader: Loader = {
+  name: "cursor-slashcommands",
+  description: "Register Nori slash commands with Cursor IDE",
+  run: async (args: { config: Config }) => {
+    const { config } = args;
+    await registerSlashCommands({ config });
+  },
+  uninstall: async (args: { config: Config }) => {
+    const { config } = args;
+    await unregisterSlashCommands({ config });
+  },
+  validate,
+};


### PR DESCRIPTION
## Summary
🤖 Generated with [Nori](https://www.npmjs.com/package/nori-ai)

- Add `getCursorCommandsDir` helper to env.ts for Cursor commands directory path
- Create `cursorSlashCommandsLoader` that installs Nori's global slash commands to `~/.cursor/commands/`
- Register new loader in CursorLoaderRegistry alongside existing profiles loader
- Reuses shared command markdown files from `src/cli/features/slashcommands/config/` (no duplication)

## Test Plan
- [x] All 713 tests pass (added 14 new tests)
- [x] Verified loader registration in CursorLoaderRegistry
- [x] Verified template substitution uses Cursor paths
- [ ] Manual: Run `nori-ai install-cursor` and verify commands appear in `~/.cursor/commands/`

Share Nori with your team: https://www.npmjs.com/package/nori-ai