### PR TITLE
Remove stale claudemd/config references from build script

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -111,14 +111,12 @@ echo ""
 echo -e "${BLUE}[6/7] Copying configuration files...${NC}"
 
 # Create required directories
-mkdir -p build/src/cli/features/claudemd/config
 mkdir -p build/src/cli/features/hooks/config
 mkdir -p build/src/cli/features/statusline/config
 mkdir -p build/src/cli/features/profiles/config
 mkdir -p build/src/cli/features/slashcommands/config
 
 # Copy configuration files for specific features that still have config dirs
-cp src/cli/features/claudemd/config/*.md build/src/cli/features/claudemd/config/ 2>/dev/null || true
 cp src/cli/features/hooks/config/*.sh build/src/cli/features/hooks/config/ 2>/dev/null || true
 cp src/cli/features/statusline/config/*.sh build/src/cli/features/statusline/config/ 2>/dev/null || true
 cp src/cli/features/slashcommands/config/*.md build/src/cli/features/slashcommands/config/ 2>/dev/null || true


### PR DESCRIPTION
## Summary
🤖 Generated with [Nori](https://www.npmjs.com/package/nori-ai)

- Remove stale references to non-existent `src/cli/features/claudemd/config/` directory from build script
- The `claudemd` feature was moved to `src/cli/features/profiles/claudemd/` and no longer uses a separate config directory
- Build script was creating an empty directory and silently failing to copy files

## Test Plan
- [x] All 671 tests pass
- [x] Build completes successfully
- [x] Verify `build/src/cli/features/claudemd/config/` is no longer created after build

Share Nori with your team: https://www.npmjs.com/package/nori-ai