### PR TITLE
fix: copy cursor-agent slashcommands config to build output

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -128,6 +128,10 @@ cp -r src/cli/features/claude-code/profiles/config/* build/src/cli/features/clau
 mkdir -p build/src/cli/features/cursor-agent/profiles/config
 cp -r src/cli/features/cursor-agent/profiles/config/* build/src/cli/features/cursor-agent/profiles/config/ 2>/dev/null || true
 
+# Copy cursor-agent slashcommands config
+mkdir -p build/src/cli/features/cursor-agent/slashcommands/config
+cp src/cli/features/cursor-agent/slashcommands/config/*.md build/src/cli/features/cursor-agent/slashcommands/config/ 2>/dev/null || true
+
 # Make shell scripts executable
 chmod +x build/src/cli/features/claude-code/hooks/config/*.sh 2>/dev/null || true
 chmod +x build/src/cli/features/claude-code/statusline/config/*.sh 2>/dev/null || true

--- a/src/build.test.ts
+++ b/src/build.test.ts
@@ -374,6 +374,30 @@ ${stderr || "(empty)"}`,
     });
   });
 
+  it("should copy cursor-agent slashcommands config files to build", () => {
+    // This test verifies that the build script copies cursor-agent slash command
+    // markdown files to the build directory. Without this, running
+    // `nori-ai install --agent cursor-agent` fails with ENOENT error when
+    // the loader tries to read from the config directory.
+
+    const pluginDir = process.cwd();
+    const configDir = path.join(
+      pluginDir,
+      "build/src/cli/features/cursor-agent/slashcommands/config",
+    );
+
+    // Check that the config directory exists
+    expect(fs.existsSync(configDir)).toBe(true);
+
+    // Check that at least one .md file exists
+    const files = fs.readdirSync(configDir);
+    const mdFiles = files.filter((f) => f.endsWith(".md"));
+    expect(mdFiles.length).toBeGreaterThan(0);
+
+    // Specifically check for nori-info.md which should always be present
+    expect(mdFiles).toContain("nori-info.md");
+  });
+
   // CLI behavior tests - these run after build tests to ensure build artifacts exist
   describe("CLI behavior", () => {
     let tempDir: string;


### PR DESCRIPTION
## Summary
🤖 Generated with [Nori](https://www.npmjs.com/package/nori-ai)

- Add missing build script step to copy cursor-agent slashcommands config directory to build output
- Fixes ENOENT error when running `nori-ai install --agent cursor-agent`
- Add test to verify the config files are copied during build

## Test Plan
- [x] All 836 tests pass (including new test)
- [x] Lint and format pass
- [ ] Manual verification: Run `nori-ai install --agent cursor-agent` in a test directory

Share Nori with your team: https://www.npmjs.com/package/nori-ai