### PR TITLE
fix: auto-detect agent from config in non-interactive uninstall mode

### DIFF
--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -33,7 +33,10 @@ program
     (value) => normalizeInstallDir({ installDir: value }),
   )
   .option("-n, --non-interactive", "Run without interactive prompts")
-  .option("-a, --agent <name>", "AI agent to use (claude-code)", "claude-code")
+  .option(
+    "-a, --agent <name>",
+    "AI agent to use (auto-detected from config, or claude-code)",
+  )
   .addHelpText(
     "after",
     `

--- a/src/cli/commands/docs.md
+++ b/src/cli/commands/docs.md
@@ -27,6 +27,8 @@ Each agent declares its own global features (e.g., claude-code has hooks, status
 
 The install command sets `installedAgents: [agentName]` in the config, which the config loader merges with any existing agents. The uninstall command prompts the user to select which agent to uninstall when multiple agents are installed at a location (in interactive mode).
 
+**Uninstall Agent Detection:** In non-interactive mode (used during upgrades), the uninstall command auto-detects the agent from config when `--agent` is not explicitly provided. If exactly one agent is in `installedAgents`, it uses that agent; otherwise it defaults to `claude-code`. This ensures the correct agent is uninstalled during autoupdate scenarios without requiring explicit `--agent` flags in older installed versions.
+
 ```
 cli.ts
   |

--- a/src/cli/commands/uninstall/docs.md
+++ b/src/cli/commands/uninstall/docs.md
@@ -1,0 +1,61 @@
+# Noridoc: uninstall
+
+Path: @/src/cli/commands/uninstall
+
+### Overview
+
+- Removes Nori Profiles features from the system, including agent-specific files (CLAUDE.md/AGENTS.md), profiles, skills, subagents, and slash commands
+- Supports both interactive and non-interactive modes with different behaviors for config preservation
+- Auto-detects which agent to uninstall from the config when `--agent` is not explicitly provided
+
+### How it fits into the larger codebase
+
+- Registered via `registerUninstallCommand()` called from @/src/cli/cli.ts
+- Uses `AgentRegistry` (@/src/cli/features/agentRegistry.ts) to get agent-specific loaders
+- Executes loaders in REVERSE order via `registry.getAllReversed()` - critical because profiles must be removed LAST (other loaders need profile directories to know what to remove)
+- Called by the install command during upgrades to clean up the previous version before installing the new one
+- Reads `installedAgents` from config (@/src/cli/config.ts) to detect which agents are installed at a location
+
+### Core Implementation
+
+**Entry Points:**
+
+| Function | Mode | Config Preservation | Agent Detection |
+|----------|------|---------------------|-----------------|
+| `main()` | Routes to interactive/non-interactive | - | Passes through |
+| `interactive()` | Prompts user | Removes config | Prompts if multiple agents |
+| `noninteractive()` | No prompts | Preserves config | Auto-detects from config |
+
+**Agent Detection in Non-Interactive Mode:**
+
+When `--agent` is not explicitly provided, `noninteractive()` reads the config and:
+- If exactly one agent in `installedAgents` → uses that agent
+- If zero agents or multiple agents → defaults to `claude-code`
+
+This ensures that during autoupdate/upgrade scenarios, the correct agent is uninstalled without requiring explicit `--agent` flags.
+
+**Interactive Mode Agent Selection:**
+
+- If `--agent` provided → uses that agent
+- If single agent installed → auto-selects it
+- If multiple agents installed → displays numbered list and prompts user to select
+
+**Loader Execution:**
+
+Loaders execute in reverse order from install. Each loader's `uninstall({ config })` is called with the config containing `installedAgents: [agentName]` so the loader knows which agent is being removed. Global loaders (hooks, statusline, slashcommands) can be skipped via `removeGlobalSettings: false`.
+
+**Feature List Display:**
+
+In interactive mode, the feature list ("The following will be removed:") is built dynamically from the agent's loader descriptions via `registry.getAll()` rather than hardcoded, ensuring each agent shows its own features.
+
+### Things to Know
+
+- **Reverse loader order is critical:** During install, profiles loader runs first to create directories. During uninstall, profiles must run LAST so other loaders can still access profile directories to determine which files to remove.
+
+- **Config preservation during upgrades:** Non-interactive mode (used by install command during upgrades) preserves the config file and global settings. Only user-initiated uninstalls remove the config.
+
+- **Global settings are shared:** Global features (hooks, statusline, global slash commands) are installed in `~/.claude/` and shared across all Nori installations. Interactive mode prompts about removing them; non-interactive mode always preserves them.
+
+- **installedAgents field:** The config loader uses `config.installedAgents` to know which agent is being uninstalled. If other agents remain after uninstall, the config file is preserved with updated `installedAgents` list.
+
+Created and maintained by Nori.

--- a/src/cli/docs.md
+++ b/src/cli/docs.md
@@ -16,9 +16,9 @@ CLI for Nori Profiles that prompts for configuration, installs features into Cla
 |--------|-------------|
 | `-d, --install-dir <path>` | Custom installation directory (default: current working directory) |
 | `-n, --non-interactive` | Run without interactive prompts |
-| `-a, --agent <name>` | AI agent to use (default: "claude-code") |
+| `-a, --agent <name>` | AI agent to use (auto-detected from config, or defaults to claude-code) |
 
-The `--agent` option enables support for multiple AI agents. Commands use the AgentRegistry (@/src/cli/features/agentRegistry.ts) to look up the agent implementation and obtain agent-specific loaders and environment paths.
+The `--agent` option enables support for multiple AI agents. Commands use the AgentRegistry (@/src/cli/features/agentRegistry.ts) to look up the agent implementation and obtain agent-specific loaders and environment paths. When `--agent` is not provided, commands may auto-detect the agent from the existing config's `installedAgents` field.
 
 **CLI Directory Structure:**
 


### PR DESCRIPTION
## Summary
🤖 Generated with [Nori](https://www.npmjs.com/package/nori-ai)

- Auto-detect installed agent from config in non-interactive uninstall mode (used during upgrades)
- Remove misleading "No existing configuration found" message when config exists without paid auth
- Make feature list dynamic using loader descriptions instead of hardcoded list
- Fix root cause: remove default value from --agent CLI option that was bypassing detection

This ensures the correct agent is uninstalled during autoupdate scenarios without requiring explicit `--agent` flags.

## Test Plan
- [x] Added tests for cursor-agent detection from config
- [x] Added tests for claude-code detection from config
- [x] Added tests for default to claude-code when no agents in config
- [x] Added tests for default to claude-code when multiple agents installed
- [x] All 1068 tests pass
- [x] Manual testing with test script installing claude-code at home, cursor-agent at project, then uninstalling

Share Nori with your team: https://www.npmjs.com/package/nori-ai