### PR TITLE
Fix cursor-agent ANSI escape codes not rendering in Cursor IDE

### DIFF
--- a/src/cli/features/cursor-agent/docs.md
+++ b/src/cli/features/cursor-agent/docs.md
@@ -113,10 +113,12 @@ hooks/
     ├── slash-command-intercept.ts  # Slash command interception (beforeSubmitPrompt event)
     └── intercepted-slashcommands/  # Command implementations
         ├── types.ts       # CursorHookInput/Output, HookInput/Output, InterceptedSlashCommand
-        ├── format.ts      # ANSI color formatting (formatSuccess, formatError)
+        ├── format.ts      # Plain text formatting with Unicode symbols (✓/✗)
         ├── registry.ts    # Array of InterceptedSlashCommand (first match wins)
         └── nori-switch-profile.ts  # Profile switching implementation
 ```
+
+**format.ts uses plain text (not ANSI codes):** Unlike claude-code which runs in a terminal and can use ANSI escape codes for colored output, cursor-agent's hook output is displayed in Cursor IDE's web-based chat UI which renders ANSI codes as raw escape sequences (e.g., `\u001b[0;32m`). Therefore, cursor-agent's format.ts uses Unicode symbols (✓ for success, ✗ for error) as visual prefixes instead of colors.
 
 The notify-hook.sh script is a cross-platform bash script supporting Linux (notify-send), macOS (osascript/terminal-notifier), and Windows (PowerShell). The slash-command-intercept.ts is a Node.js script that reads Cursor's hook input from stdin, matches against registered commands, and outputs Cursor's expected response format. Cursor's hooks.json format is `{ version: 1, hooks: { [event]: [{ command: "..." }] } }`. The loader identifies Nori hooks by checking if the command path contains "notify-hook.sh" or "slash-command-intercept.js".
 

--- a/src/cli/features/cursor-agent/hooks/config/intercepted-slashcommands/format.test.ts
+++ b/src/cli/features/cursor-agent/hooks/config/intercepted-slashcommands/format.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Tests for cursor-agent format utilities
+ *
+ * Cursor IDE does not render ANSI escape codes in its UI,
+ * so format functions must return plain text (no ANSI codes).
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { formatError, formatSuccess } from "./format.js";
+
+// ANSI escape code pattern - should NOT be present in output
+const ANSI_PATTERN = /\x1b\[[0-9;]*m/;
+
+describe("formatSuccess", () => {
+  it("should return plain text without ANSI codes", () => {
+    const result = formatSuccess({ message: "Hello world" });
+
+    expect(result).not.toMatch(ANSI_PATTERN);
+  });
+
+  it("should prefix message with success symbol", () => {
+    const result = formatSuccess({ message: "Operation complete" });
+
+    expect(result).toBe("✓ Operation complete");
+  });
+
+  it("should preserve multiline messages", () => {
+    const result = formatSuccess({ message: "Line 1\nLine 2\nLine 3" });
+
+    expect(result).toBe("✓ Line 1\nLine 2\nLine 3");
+    expect(result).not.toMatch(ANSI_PATTERN);
+  });
+
+  it("should handle empty message", () => {
+    const result = formatSuccess({ message: "" });
+
+    expect(result).toBe("✓ ");
+    expect(result).not.toMatch(ANSI_PATTERN);
+  });
+});
+
+describe("formatError", () => {
+  it("should return plain text without ANSI codes", () => {
+    const result = formatError({ message: "Something went wrong" });
+
+    expect(result).not.toMatch(ANSI_PATTERN);
+  });
+
+  it("should prefix message with error symbol", () => {
+    const result = formatError({ message: "File not found" });
+
+    expect(result).toBe("✗ File not found");
+  });
+
+  it("should preserve multiline messages", () => {
+    const result = formatError({ message: "Error 1\nError 2" });
+
+    expect(result).toBe("✗ Error 1\nError 2");
+    expect(result).not.toMatch(ANSI_PATTERN);
+  });
+
+  it("should handle empty message", () => {
+    const result = formatError({ message: "" });
+
+    expect(result).toBe("✗ ");
+    expect(result).not.toMatch(ANSI_PATTERN);
+  });
+});

--- a/src/cli/features/cursor-agent/hooks/config/intercepted-slashcommands/format.ts
+++ b/src/cli/features/cursor-agent/hooks/config/intercepted-slashcommands/format.ts
@@ -1,89 +1,39 @@
 /**
  * Formatting utilities for cursor-agent intercepted slash command output
+ *
+ * NOTE: Cursor IDE does not render ANSI escape codes in its UI chat interface.
+ * Unlike Claude Code which runs in a terminal, Cursor's hook output is displayed
+ * in a web-based UI that shows raw escape sequences as text.
+ *
+ * Therefore, this module uses plain text with Unicode symbols for visual distinction.
  */
 
-// ANSI color codes
-const GREEN = "\x1b[0;32m";
-const RED = "\x1b[0;31m";
-const NC = "\x1b[0m"; // No Color / Reset
+// Unicode symbols for visual distinction (no ANSI codes)
+const SUCCESS_SYMBOL = "\u2713"; // ✓
+const ERROR_SYMBOL = "\u2717"; // ✗
 
 /**
- * Color each word in a line individually
- * This ensures colors persist when the terminal re-wraps at any width
- *
- * @param args - The function arguments
- * @param args.line - The line to color
- * @param args.color - The ANSI color code to apply
- *
- * @returns The line with each word colored individually
- */
-const colorLineWords = (args: { line: string; color: string }): string => {
-  const { line, color } = args;
-
-  if (line.length === 0) {
-    return "";
-  }
-
-  // Use regex to split while preserving whitespace structure
-  // This matches sequences of non-space characters (words) or sequences of spaces
-  const tokens = line.match(/\S+|\s+/g) ?? [];
-
-  return tokens
-    .map((token) => {
-      // Only color non-whitespace tokens (words)
-      if (/^\s+$/.test(token)) {
-        return token;
-      }
-      return `${color}${token}${NC}`;
-    })
-    .join("");
-};
-
-/**
- * Format a message with color, coloring each word individually
- * This approach ensures colors persist regardless of terminal width,
- * since each word has its own color codes that survive re-wrapping
- *
- * @param args - The function arguments
- * @param args.message - The message to format
- * @param args.color - The ANSI color code to apply
- *
- * @returns The message with colors that persist across any terminal width
- */
-const formatWithColor = (args: { message: string; color: string }): string => {
-  const { message, color } = args;
-
-  // Split by explicit newlines, color each line's words, rejoin
-  return message
-    .split("\n")
-    .map((line) => colorLineWords({ line, color }))
-    .join("\n");
-};
-
-/**
- * Format a success message with green color
- * Colors each word individually to ensure colors persist across terminal re-wrapping
+ * Format a success message with a checkmark symbol
  *
  * @param args - The function arguments
  * @param args.message - The message to format
  *
- * @returns The message formatted with green color
+ * @returns The message prefixed with a success symbol
  */
 export const formatSuccess = (args: { message: string }): string => {
   const { message } = args;
-  return formatWithColor({ message, color: GREEN });
+  return `${SUCCESS_SYMBOL} ${message}`;
 };
 
 /**
- * Format an error message with red color
- * Colors each word individually to ensure colors persist across terminal re-wrapping
+ * Format an error message with an X symbol
  *
  * @param args - The function arguments
  * @param args.message - The message to format
  *
- * @returns The message formatted with red color
+ * @returns The message prefixed with an error symbol
  */
 export const formatError = (args: { message: string }): string => {
   const { message } = args;
-  return formatWithColor({ message, color: RED });
+  return `${ERROR_SYMBOL} ${message}`;
 };

--- a/src/cli/features/cursor-agent/hooks/config/intercepted-slashcommands/nori-registry-update.test.ts
+++ b/src/cli/features/cursor-agent/hooks/config/intercepted-slashcommands/nori-registry-update.test.ts
@@ -37,10 +37,13 @@ import type { HookInput } from "./types.js";
 
 import { noriRegistryUpdate } from "./nori-registry-update.js";
 
-// ANSI color codes for verification
-const GREEN = "\x1b[0;32m";
-const RED = "\x1b[0;31m";
-const NC = "\x1b[0m"; // No Color / Reset
+// Unicode symbols for cursor-agent output (no ANSI codes)
+const SUCCESS_SYMBOL = "\u2713"; // ✓
+const ERROR_SYMBOL = "\u2717"; // ✗
+
+// ANSI pattern to verify output contains no escape codes
+// eslint-disable-next-line no-control-regex
+const ANSI_PATTERN = /\x1b\[[0-9;]*m/;
 
 /**
  * Strip ANSI escape codes from a string for plain text comparison
@@ -496,8 +499,8 @@ describe("nori-registry-update", () => {
     });
   });
 
-  describe("ANSI color formatting", () => {
-    it("should format successful update with green color codes", async () => {
+  describe("output formatting (no ANSI codes)", () => {
+    it("should format successful update with success symbol and no ANSI codes", async () => {
       const profileDir = path.join(profilesDir, "test-profile");
       await fs.mkdir(profileDir, { recursive: true });
       await fs.writeFile(
@@ -531,11 +534,11 @@ describe("nori-registry-update", () => {
       const result = await noriRegistryUpdate.run({ input });
 
       expect(result).not.toBeNull();
-      expect(result!.reason).toContain(GREEN);
-      expect(result!.reason).toContain(NC);
+      expect(result!.reason).toContain(SUCCESS_SYMBOL);
+      expect(result!.reason).not.toMatch(ANSI_PATTERN);
     });
 
-    it("should format no installation error with red color codes", async () => {
+    it("should format no installation error with error symbol and no ANSI codes", async () => {
       const noInstallDir = await fs.mkdtemp(
         path.join(tmpdir(), "nori-update-no-install-"),
       );
@@ -548,14 +551,14 @@ describe("nori-registry-update", () => {
         const result = await noriRegistryUpdate.run({ input });
 
         expect(result).not.toBeNull();
-        expect(result!.reason).toContain(RED);
-        expect(result!.reason).toContain(NC);
+        expect(result!.reason).toContain(ERROR_SYMBOL);
+        expect(result!.reason).not.toMatch(ANSI_PATTERN);
       } finally {
         await fs.rm(noInstallDir, { recursive: true, force: true });
       }
     });
 
-    it("should format already at latest with green color codes", async () => {
+    it("should format already at latest with success symbol and no ANSI codes", async () => {
       const profileDir = path.join(profilesDir, "test-profile");
       await fs.mkdir(profileDir, { recursive: true });
       await fs.writeFile(
@@ -586,8 +589,8 @@ describe("nori-registry-update", () => {
       const result = await noriRegistryUpdate.run({ input });
 
       expect(result).not.toBeNull();
-      expect(result!.reason).toContain(GREEN);
-      expect(result!.reason).toContain(NC);
+      expect(result!.reason).toContain(SUCCESS_SYMBOL);
+      expect(result!.reason).not.toMatch(ANSI_PATTERN);
     });
   });
 

--- a/src/cli/features/cursor-agent/hooks/config/intercepted-slashcommands/nori-registry-upload.test.ts
+++ b/src/cli/features/cursor-agent/hooks/config/intercepted-slashcommands/nori-registry-upload.test.ts
@@ -29,10 +29,13 @@ import type { HookInput } from "./types.js";
 
 import { noriRegistryUpload } from "./nori-registry-upload.js";
 
-// ANSI color codes for verification
-const GREEN = "\x1b[0;32m";
-const RED = "\x1b[0;31m";
-const NC = "\x1b[0m"; // No Color / Reset
+// Unicode symbols for cursor-agent output (no ANSI codes)
+const SUCCESS_SYMBOL = "\u2713"; // ✓
+const ERROR_SYMBOL = "\u2717"; // ✗
+
+// ANSI pattern to verify output contains no escape codes
+// eslint-disable-next-line no-control-regex
+const ANSI_PATTERN = /\x1b\[[0-9;]*m/;
 
 /**
  * Strip ANSI escape codes from a string for plain text comparison
@@ -547,8 +550,8 @@ describe("nori-registry-upload", () => {
     });
   });
 
-  describe("ANSI color formatting", () => {
-    it("should format success upload with green color codes", async () => {
+  describe("output formatting (no ANSI codes)", () => {
+    it("should format success upload with success symbol and no ANSI codes", async () => {
       await createConfigWithRegistryAuth();
       await createTestProfile({ name: "test-profile" });
 
@@ -566,11 +569,11 @@ describe("nori-registry-upload", () => {
       const result = await noriRegistryUpload.run({ input });
 
       expect(result).not.toBeNull();
-      expect(result!.reason).toContain(GREEN);
-      expect(result!.reason).toContain(NC);
+      expect(result!.reason).toContain(SUCCESS_SYMBOL);
+      expect(result!.reason).not.toMatch(ANSI_PATTERN);
     });
 
-    it("should format error messages with red color codes", async () => {
+    it("should format error messages with error symbol and no ANSI codes", async () => {
       await createConfigWithRegistryAuth();
 
       const input = createInput({
@@ -579,11 +582,11 @@ describe("nori-registry-upload", () => {
       const result = await noriRegistryUpload.run({ input });
 
       expect(result).not.toBeNull();
-      expect(result!.reason).toContain(RED);
-      expect(result!.reason).toContain(NC);
+      expect(result!.reason).toContain(ERROR_SYMBOL);
+      expect(result!.reason).not.toMatch(ANSI_PATTERN);
     });
 
-    it("should format help message with green color codes", async () => {
+    it("should format help message with success symbol and no ANSI codes", async () => {
       await createConfigWithRegistryAuth();
 
       const input = createInput({
@@ -592,8 +595,8 @@ describe("nori-registry-upload", () => {
       const result = await noriRegistryUpload.run({ input });
 
       expect(result).not.toBeNull();
-      expect(result!.reason).toContain(GREEN);
-      expect(result!.reason).toContain(NC);
+      expect(result!.reason).toContain(SUCCESS_SYMBOL);
+      expect(result!.reason).not.toMatch(ANSI_PATTERN);
     });
   });
 


### PR DESCRIPTION
## Summary
🤖 Generated with [Nori](https://www.npmjs.com/package/nori-ai)

- Replace ANSI color codes with plain text and Unicode symbols (✓/✗) in cursor-agent's format.ts
- Cursor IDE's web-based chat UI doesn't render ANSI codes, causing users to see raw escape sequences like `\u001b[0;32m`
- Added dedicated format.test.ts with 8 tests for the new behavior

## Test Plan
- [x] All 1257 tests pass (8 new tests added)
- [x] Format and lint pass
- [ ] Manually verify slash commands in Cursor IDE show ✓/✗ symbols instead of ANSI codes

Share Nori with your team: https://www.npmjs.com/package/nori-ai