### PR TITLE
Fix CLI_ROOT path resolution to work from any directory

### DIFF
--- a/src/cli/env.test.ts
+++ b/src/cli/env.test.ts
@@ -2,6 +2,7 @@
  * Tests for environment constants
  */
 
+import * as fs from "fs";
 import * as path from "path";
 
 import { describe, it, expect } from "vitest";
@@ -14,9 +15,12 @@ describe("CLI_ROOT", () => {
   });
 
   it("should point to the package root directory", () => {
-    // CLI_ROOT should be the directory containing package.json
-    // It should be 3 levels up from src/cli/env.ts -> ../../.. -> root
-    expect(CLI_ROOT).toContain("nori-profiles");
+    // CLI_ROOT should be the directory containing package.json with name "nori-ai"
+    const packageJsonPath = path.join(CLI_ROOT, "package.json");
+    expect(fs.existsSync(packageJsonPath)).toBe(true);
+
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8"));
+    expect(packageJson.name).toBe("nori-ai");
   });
 
   it("should not contain src directory", () => {

--- a/src/cli/env.ts
+++ b/src/cli/env.ts
@@ -3,12 +3,45 @@
  * Contains only CLI-level concerns. Agent-specific paths are in their respective feature directories.
  */
 
+import * as fs from "fs";
 import * as path from "path";
 import { fileURLToPath } from "url";
+
+/**
+ * Find the package root by walking up the directory tree looking for package.json with name "nori-ai"
+ * @param args - Function arguments
+ * @param args.startDir - Directory to start searching from
+ *
+ * @returns The package root directory path
+ */
+const findPackageRoot = (args: { startDir: string }): string => {
+  const { startDir } = args;
+  let currentDir = startDir;
+
+  while (currentDir !== path.dirname(currentDir)) {
+    const packageJsonPath = path.join(currentDir, "package.json");
+    if (fs.existsSync(packageJsonPath)) {
+      try {
+        const packageJson = JSON.parse(
+          fs.readFileSync(packageJsonPath, "utf-8"),
+        );
+        if (packageJson.name === "nori-ai") {
+          return currentDir;
+        }
+      } catch {
+        // Continue searching if we can't parse this package.json
+      }
+    }
+    currentDir = path.dirname(currentDir);
+  }
+
+  // Fallback to relative path from this file if package.json not found
+  return path.resolve(startDir, "../../..");
+};
 
 /**
  * CLI root directory (where package.json is located)
  */
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-export const CLI_ROOT = path.resolve(__dirname, "../../..");
+export const CLI_ROOT = findPackageRoot({ startDir: __dirname });


### PR DESCRIPTION
## Summary
🤖 Generated with [Nori](https://www.npmjs.com/package/nori-ai)

- Replace hardcoded relative path (`../../..`) with dynamic lookup that walks up the directory tree to find `package.json` with `name: "nori-ai"`
- Fix test failures when running from different working directories (e.g., parent directories or vitest cache locations)
- Update test to verify `package.json` exists with correct name instead of checking for substring in path

## Test Plan
- [x] All 1267 tests pass
- [x] Lint and format pass
- [ ] CI passes

Share Nori with your team: https://www.npmjs.com/package/nori-ai