### PR TITLE
Fix install command to set agents field in config

### DIFF
--- a/src/cli/commands/docs.md
+++ b/src/cli/commands/docs.md
@@ -33,7 +33,7 @@ The uninstall command uses two agent methods for global features:
 
 Each agent declares its own global features (e.g., claude-code has hooks, statusline, and global slash commands; cursor-agent has hooks and slash commands). If an agent has no global features, the global settings prompt is skipped entirely.
 
-The install command sets `installedAgents: [agentName]` in the config, which the config loader merges with any existing agents. The uninstall command prompts the user to select which agent to uninstall when multiple agents are installed at a location (in interactive mode).
+The install command sets both `agents: { [agentName]: { profile } }` (the per-agent profile configuration) and `installedAgents: [agentName]` (the list of installed agents) in the config. The config loader merges `installedAgents` with any existing agents. The uninstall command prompts the user to select which agent to uninstall when multiple agents are installed at a location (in interactive mode).
 
 **Uninstall Agent Detection:** In non-interactive mode (used during upgrades), the uninstall command auto-detects the agent from config when `--agent` is not explicitly provided. If exactly one agent is in `installedAgents`, it uses that agent; otherwise it defaults to `claude-code`. This ensures the correct agent is uninstalled during autoupdate scenarios without requiring explicit `--agent` flags in older installed versions.
 

--- a/src/cli/commands/install/install.integration.test.ts
+++ b/src/cli/commands/install/install.integration.test.ts
@@ -519,6 +519,26 @@ describe("install integration test", () => {
     expect(config.installedAgents).toHaveLength(2);
   });
 
+  it("should include agents field with agent-specific profile in config after installation", async () => {
+    const CONFIG_PATH = getConfigPath({ installDir: tempDir });
+
+    // STEP 1: Run installation in non-interactive mode (uses default profile senior-swe)
+    await installMain({ nonInteractive: true, installDir: tempDir });
+
+    // STEP 2: Verify agents field is set with agent-specific profile
+    const config = JSON.parse(fs.readFileSync(CONFIG_PATH, "utf-8"));
+
+    // The agents field should exist and contain the claude-code agent's profile
+    expect(config.agents).toBeDefined();
+    expect(config.agents["claude-code"]).toBeDefined();
+    expect(config.agents["claude-code"].profile).toEqual({
+      baseProfile: "senior-swe",
+    });
+
+    // Legacy profile field should also be set for backwards compatibility
+    expect(config.profile).toEqual({ baseProfile: "senior-swe" });
+  });
+
   it("should warn when ancestor directory has nori installation", async () => {
     // Setup: Create a parent directory with a nori installation
     const parentDir = path.join(tempDir, "parent");

--- a/src/cli/commands/install/install.ts
+++ b/src/cli/commands/install/install.ts
@@ -126,11 +126,19 @@ export const generatePromptConfig = async (args: {
 
     if (useExisting.match(/^[Yy]$/)) {
       info({ message: "Using existing configuration..." });
+      const profile = existingConfig.profile ?? getDefaultProfile();
+      const existingInstalledAgents = existingConfig.installedAgents ?? [];
       return {
         ...existingConfig,
-        profile: existingConfig.profile ?? getDefaultProfile(),
+        profile,
+        agents: {
+          ...(existingConfig.agents ?? {}),
+          [agent.name]: { profile },
+        },
         installDir,
-        installedAgents: [agent.name],
+        installedAgents: existingInstalledAgents.includes(agent.name)
+          ? existingInstalledAgents
+          : [...existingInstalledAgents, agent.name],
       };
     }
 
@@ -242,14 +250,20 @@ export const generatePromptConfig = async (args: {
   });
 
   // Build config directly
+  const profile = { baseProfile: selectedProfileName };
+  const existingInstalledAgents = existingConfig?.installedAgents ?? [];
   return {
     auth: auth ?? null,
-    profile: {
-      baseProfile: selectedProfileName,
+    profile,
+    agents: {
+      ...(existingConfig?.agents ?? {}),
+      [agent.name]: { profile },
     },
     installDir,
     registryAuths: registryAuths ?? null,
-    installedAgents: [agent.name],
+    installedAgents: existingInstalledAgents.includes(agent.name)
+      ? existingInstalledAgents
+      : [...existingInstalledAgents, agent.name],
   };
 };
 
@@ -546,13 +560,25 @@ export const noninteractive = async (args?: {
     installDir: normalizedInstallDir,
   });
 
+  const existingInstalledAgents = existingConfig?.installedAgents ?? [];
   const config: Config = existingConfig
     ? {
         ...existingConfig,
-        installedAgents: [agentImpl.name],
+        agents: {
+          ...(existingConfig.agents ?? {}),
+          [agentImpl.name]: {
+            profile: existingConfig.profile ?? getDefaultProfile(),
+          },
+        },
+        installedAgents: existingInstalledAgents.includes(agentImpl.name)
+          ? existingInstalledAgents
+          : [...existingInstalledAgents, agentImpl.name],
       }
     : {
         profile: getDefaultProfile(),
+        agents: {
+          [agentImpl.name]: { profile: getDefaultProfile() },
+        },
         installDir: normalizedInstallDir,
         installedAgents: [agentImpl.name],
       };


### PR DESCRIPTION
## Summary
🤖 Generated with [Nori](https://www.npmjs.com/package/nori-ai)

During installation, the config was only setting the deprecated `profile` field. This fix ensures the `agents` field is set with per-agent profile configuration, enabling multi-agent installations.

Changes:
- Set `agents` field (with proper merging for existing agents) in all 4 config construction locations in `install.ts`
- Merge `installedAgents` array instead of replacing, to preserve other installed agents
- Add integration test verifying `agents` field is set after installation
- Update `docs.md` with documentation about the config fields

The fix now properly builds configs like:
```json
{
  "agents": {
    "claude-code": { "profile": { "baseProfile": "senior-swe" } }
  },
  "installedAgents": ["claude-code"]
}
```

## Test Plan
- [x] All 10 install integration tests pass
- [x] New test verifies `agents` field is set with agent-specific profile
- [x] Format and lint pass
- [x] Code review identified and fixed potential data loss in multi-agent scenarios

Share Nori with your team: https://www.npmjs.com/package/nori-ai