### PR TITLE
fix: Allow installation to continue when authentication fails

### DIFF
--- a/src/cli/features/config/loader.ts
+++ b/src/cli/features/config/loader.ts
@@ -14,7 +14,7 @@ import {
   isPaidInstall,
   getInstalledAgents,
 } from "@/cli/config.js";
-import { info, success, error, debug } from "@/cli/logger.js";
+import { info, success, error, warn, debug } from "@/cli/logger.js";
 import { getCurrentPackageVersion } from "@/cli/version.js";
 import { configureFirebase, getFirebase } from "@/providers/firebase.js";
 
@@ -110,7 +110,11 @@ const installConfig = async (args: { config: Config }): Promise<void> => {
         });
       }
 
-      throw err;
+      // Don't halt installation - continue without authentication
+      warn({
+        message:
+          "  Continuing installation without authentication. Backend features will be unavailable.",
+      });
     }
   }
 


### PR DESCRIPTION
## Summary
- Authentication errors during installation no longer halt the entire install process
- When authentication fails (wrong password, network issues, etc.), a warning is displayed and installation proceeds without backend features
- Users can still use local-only features even if they enter incorrect credentials

## Test plan
- [ ] Run `nori-ai install` with incorrect Watchtower credentials - should warn but continue
- [ ] Run `nori-ai install` with no network - should warn but continue
- [ ] Run `nori-ai install` with correct credentials - should authenticate successfully as before
- [ ] Verify installation completes and all local features work after auth failure