### PR TITLE
fix: Warn users about expected hook errors during auto-update

### DIFF
--- a/src/cli/features/claude-code/hooks/config/autoupdate.test.ts
+++ b/src/cli/features/claude-code/hooks/config/autoupdate.test.ts
@@ -131,13 +131,13 @@ describe("autoupdate", () => {
       // Verify child.unref was called
       expect(mockChild.unref).toHaveBeenCalled();
 
-      // Verify user notification was logged
+      // Verify user notification was logged with warning about hook errors
       expect(consoleLogSpy).toHaveBeenCalled();
       const logOutput = consoleLogSpy.mock.calls[0][0];
       const parsed = JSON.parse(logOutput);
       expect(parsed.systemMessage).toContain("14.1.0"); // current version
       expect(parsed.systemMessage).toContain("14.2.0"); // new version
-      expect(parsed.systemMessage).toContain("update available");
+      expect(parsed.systemMessage).toContain("updating");
 
       consoleLogSpy.mockRestore();
     });
@@ -1001,11 +1001,13 @@ describe("autoupdate", () => {
       const spawnCall = mockSpawn.mock.calls[0];
       expect(spawnCall[1][1]).toContain("nori-ai install --non-interactive");
 
-      // Verify notification was about installing, not just available
+      // Verify notification warns about hook errors at session end
       expect(consoleLogSpy).toHaveBeenCalled();
       const logOutput = consoleLogSpy.mock.calls[0][0];
       const parsed = JSON.parse(logOutput);
-      expect(parsed.systemMessage).toContain("Installing in background");
+      expect(parsed.systemMessage).toContain(
+        "Restart Claude to use the new version",
+      );
 
       consoleLogSpy.mockRestore();
     });

--- a/src/cli/features/claude-code/hooks/config/autoupdate.ts
+++ b/src/cli/features/claude-code/hooks/config/autoupdate.ts
@@ -198,8 +198,11 @@ const main = async (): Promise<void> => {
   });
 
   // Notify user via additionalContext
+  // Note: Hook errors at session exit are expected because Claude Code caches hook paths
+  // at session start. The update replaces those files, causing MODULE_NOT_FOUND errors.
+  // This is harmless - the user just needs to restart Claude to use the new version.
   logToClaudeSession({
-    message: `🔄 Nori Profiles update available: v${installedVersion} → v${latestVersion}. Installing in background...`,
+    message: `🔄 Nori Profiles updating: v${installedVersion} → v${latestVersion}. You may see hook errors when this session ends - this is expected. Restart Claude to use the new version.`,
   });
 };
 

--- a/src/cli/features/cursor-agent/hooks/config/autoupdate.test.ts
+++ b/src/cli/features/cursor-agent/hooks/config/autoupdate.test.ts
@@ -128,13 +128,13 @@ describe("autoupdate", () => {
       // Verify child.unref was called
       expect(mockChild.unref).toHaveBeenCalled();
 
-      // Verify user notification was logged
+      // Verify user notification was logged with warning about hook errors
       expect(consoleLogSpy).toHaveBeenCalled();
       const logOutput = consoleLogSpy.mock.calls[0][0];
       const parsed = JSON.parse(logOutput);
       expect(parsed.systemMessage).toContain("14.1.0"); // current version
       expect(parsed.systemMessage).toContain("14.2.0"); // new version
-      expect(parsed.systemMessage).toContain("update available");
+      expect(parsed.systemMessage).toContain("updating");
 
       consoleLogSpy.mockRestore();
     });
@@ -983,11 +983,13 @@ describe("autoupdate", () => {
       const spawnCall = mockSpawn.mock.calls[0];
       expect(spawnCall[1][1]).toContain("nori-ai install --non-interactive");
 
-      // Verify notification was about installing, not just available
+      // Verify notification warns about hook errors at session end
       expect(consoleLogSpy).toHaveBeenCalled();
       const logOutput = consoleLogSpy.mock.calls[0][0];
       const parsed = JSON.parse(logOutput);
-      expect(parsed.systemMessage).toContain("Installing in background");
+      expect(parsed.systemMessage).toContain(
+        "Restart Claude to use the new version",
+      );
 
       consoleLogSpy.mockRestore();
     });
@@ -1045,11 +1047,13 @@ describe("autoupdate", () => {
         },
       );
 
-      // Verify notification was about installing
+      // Verify notification warns about hook errors at session end
       expect(consoleLogSpy).toHaveBeenCalled();
       const logOutput = consoleLogSpy.mock.calls[0][0];
       const parsed = JSON.parse(logOutput);
-      expect(parsed.systemMessage).toContain("Installing in background");
+      expect(parsed.systemMessage).toContain(
+        "Restart Claude to use the new version",
+      );
 
       consoleLogSpy.mockRestore();
     });

--- a/src/cli/features/cursor-agent/hooks/config/autoupdate.ts
+++ b/src/cli/features/cursor-agent/hooks/config/autoupdate.ts
@@ -198,8 +198,11 @@ const main = async (): Promise<void> => {
   });
 
   // Notify user via additionalContext
+  // Note: Hook errors at session exit are expected because Claude Code caches hook paths
+  // at session start. The update replaces those files, causing MODULE_NOT_FOUND errors.
+  // This is harmless - the user just needs to restart Claude to use the new version.
   logToClaudeSession({
-    message: `🔄 Nori Profiles update available: v${installedVersion} → v${latestVersion}. Installing in background...`,
+    message: `🔄 Nori Profiles updating: v${installedVersion} → v${latestVersion}. You may see hook errors when this session ends - this is expected. Restart Claude to use the new version.`,
   });
 };
 


### PR DESCRIPTION
## Summary
🤖 Generated with [Nori](https://www.npmjs.com/package/nori-ai)

- Warns users upfront when auto-update triggers that they may see hook errors at session end
- Explains these errors are expected and harmless - just restart Claude to use the new version
- Applied to both claude-code and cursor-agent autoupdate hooks

## Root Cause

When Claude Code auto-updates:
1. Claude Code caches hook paths from `settings.json` at session start
2. `npm install -g` replaces package files (including hook scripts)
3. When session ends, cached hook paths point to files that no longer exist
4. Result: `MODULE_NOT_FOUND` errors

This behavior is internal to Claude Code and cannot be fixed from our side. The solution is to set user expectations upfront.

## Test Plan
- [x] All 1254 tests pass
- [x] Format and lint pass
- [ ] Manual verification: Enable autoupdate, trigger an update, observe the new warning message

Share Nori with your team: https://www.npmjs.com/package/nori-ai