### PR TITLE
Add Ship of Theseus License addendum

### DIFF
--- a/LICENSE-ADDENDUM.txt
+++ b/LICENSE-ADDENDUM.txt
@@ -1,0 +1,11 @@
+SHIP OF THESEUS LICENSE v0.1
+
+* Using any AI tool to produce functionally equivalent software — by
+  referencing this code, its documentation, its behavior, or any
+  specification, description, or abstraction derived from the
+  foregoing — creates a derivative work subject to the full terms of
+  the primary license, regardless of whether the output shares any
+  literal code with this project.
+
+* Any derivative work must include this license alongside the
+  primary license.


### PR DESCRIPTION
## Summary
- Adds `LICENSE-ADDENDUM.txt` with the Ship of Theseus License v0.1
- Covers AI-generated functionally equivalent software as derivative works under the primary license
- Requires derivative works to include this addendum alongside the primary license

## Test plan
- [x] Verify file content matches the specified license text