### PR TITLE
fix(statusline): track tokens including cache and persist across /clear

### DIFF
--- a/src/cli/features/claude-code/statusline/config/docs.md
+++ b/src/cli/features/claude-code/statusline/config/docs.md
@@ -17,16 +17,17 @@ Path: @/src/cli/features/claude-code/statusline/config
 ### Core Implementation
 
 - Receives a JSON object on stdin from Claude Code containing `cwd`, `session_id`, `cost`, `context_window`, and `transcript_path`
-- **Tokens:** Uses `context_window.total_input_tokens` and `context_window.total_output_tokens` from stdin JSON. These fields reset automatically when `/clear` creates a new session.
-- **Context length:** Sums `context_window.current_usage.input_tokens`, `cache_read_input_tokens`, and `cache_creation_input_tokens` from stdin JSON
-- **Cost and lines changed:** Uses session-relative tracking via `session_id`. When the session ID changes (e.g., after `/clear`), the script stores the current cumulative cost/lines as a baseline in `/tmp/nori-statusline-session-<cwd-hash>`. Display values are deltas from that baseline, resetting to zero on new sessions.
+- **Tokens:** Computed from `context_window.current_usage` fields (`input_tokens`, `cache_read_input_tokens`, `cache_creation_input_tokens`, `output_tokens`) to include cached tokens. The script accumulates its own running total in a session file because Claude's `total_input_tokens` excludes cached tokens (the system prompt alone is ~27k cached tokens).
+- **Context length:** Sums `context_window.current_usage.input_tokens`, `cache_read_input_tokens`, and `cache_creation_input_tokens` -- reflects the most recent message's context size and naturally resets on `/clear`
+- **Cost and lines changed:** Displayed directly from `cost.total_cost_usd`, `cost.total_lines_added`, `cost.total_lines_removed`. These are already cumulative per Claude Code process, so they persist across `/clear` without any script-side tracking.
 - Outputs three lines with ANSI color codes: metrics line, branding line, and a status tip (promotional, update notification, or install-failure warning)
 
 ### Things to Know
 
-- Session state files are stored at `/tmp/nori-statusline-session-<md5-of-cwd>` and persist across script invocations. The file format is four lines: session_id, baseline_cost, baseline_lines_added, baseline_lines_removed.
+- Session state files are stored at `/tmp/nori-statusline-session-<md5-of-cwd>` and persist across script invocations. The file format is four lines: `session_id`, `prev_raw_total` (non-cached token total from last invocation), `accumulated_tokens` (running total including cached), `cost` (for process restart detection).
+- Process restart is detected by a cost decrease heuristic (cost going down means a new Claude Code process started). On restart, accumulated tokens reset to zero.
+- `/clear` is detected via `session_id` change; this resets the raw token tracking baseline so new API calls are correctly detected, but does not reset the accumulated token count.
 - Requires `jq` as an external dependency; falls back to a minimal warning message if `jq` is not available
-- Version comparison for update notifications uses `node -e` for cross-platform semver comparison (macOS lacks `sort -V`)
-- The script strips `-next.*` suffixes from versions before comparing, so pre-release versions are treated as their base release
+- Version comparison for update notifications uses `node -e` for cross-platform semver comparison (macOS lacks `sort -V`); `-next.*` suffixes are stripped before comparing so pre-release versions are treated as their base release
 
 Created and maintained by Nori.

--- a/src/cli/features/claude-code/statusline/config/nori-statusline.sh
+++ b/src/cli/features/claude-code/statusline/config/nori-statusline.sh
@@ -58,11 +58,13 @@ if [ -z "$BRANCH" ]; then
     BRANCH="no git"
 fi
 
-# === SESSION TRACKING FOR /clear RESET ===
-# Track session_id to detect when /clear creates a new session
-# When session changes, store baseline cost/lines so we can show deltas
-SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty')
+# === COST AND LINES (cumulative per process, no reset on /clear) ===
+COST=$(echo "$INPUT" | jq -r '.cost.total_cost_usd // 0')
+COST_FORMATTED=$(printf "%.2f" "$COST")
+LINES_ADDED=$(echo "$INPUT" | jq -r '.cost.total_lines_added // 0')
+LINES_REMOVED=$(echo "$INPUT" | jq -r '.cost.total_lines_removed // 0')
 
+# === TOKEN TRACKING (cumulative across user session, including cached tokens) ===
 # Deterministic session file based on cwd to avoid conflicts between projects
 if command -v md5sum >/dev/null 2>&1; then
     SESSION_HASH=$(echo "$CWD" | md5sum | cut -d' ' -f1)
@@ -73,62 +75,65 @@ else
 fi
 SESSION_FILE="/tmp/nori-statusline-session-${SESSION_HASH}"
 
-# Read previous session state
+# Extract raw non-cached cumulative totals (used as "new API call" signal)
+RAW_INPUT=$(echo "$INPUT" | jq -r '.context_window.total_input_tokens // 0')
+RAW_OUTPUT=$(echo "$INPUT" | jq -r '.context_window.total_output_tokens // 0')
+RAW_TOTAL=$((RAW_INPUT + RAW_OUTPUT))
+
+# Extract per-call usage (includes cached tokens)
+CALL_INPUT=$(echo "$INPUT" | jq -r '.context_window.current_usage.input_tokens // 0')
+CALL_CACHE_READ=$(echo "$INPUT" | jq -r '.context_window.current_usage.cache_read_input_tokens // 0')
+CALL_CACHE_CREATE=$(echo "$INPUT" | jq -r '.context_window.current_usage.cache_creation_input_tokens // 0')
+CALL_OUTPUT=$(echo "$INPUT" | jq -r '.context_window.current_usage.output_tokens // 0')
+CALL_TOTAL=$((CALL_INPUT + CALL_CACHE_READ + CALL_CACHE_CREATE + CALL_OUTPUT))
+
+# Read previous token tracking state
 PREV_SESSION_ID=""
-BASELINE_COST="0"
-BASELINE_LINES_ADDED="0"
-BASELINE_LINES_REMOVED="0"
+PREV_RAW_TOTAL="0"
+ACCUMULATED_TOKENS="0"
+PREV_RAW_COST="0"
 if [ -f "$SESSION_FILE" ]; then
-    PREV_SESSION_ID=$(head -1 "$SESSION_FILE" 2>/dev/null)
-    BASELINE_COST=$(sed -n '2p' "$SESSION_FILE" 2>/dev/null || echo "0")
-    BASELINE_LINES_ADDED=$(sed -n '3p' "$SESSION_FILE" 2>/dev/null || echo "0")
-    BASELINE_LINES_REMOVED=$(sed -n '4p' "$SESSION_FILE" 2>/dev/null || echo "0")
+    PREV_SESSION_ID=$(sed -n '1p' "$SESSION_FILE" 2>/dev/null || echo "")
+    PREV_RAW_TOTAL=$(sed -n '2p' "$SESSION_FILE" 2>/dev/null || echo "0")
+    ACCUMULATED_TOKENS=$(sed -n '3p' "$SESSION_FILE" 2>/dev/null || echo "0")
+    PREV_RAW_COST=$(sed -n '4p' "$SESSION_FILE" 2>/dev/null || echo "0")
 fi
 
-# Extract raw cumulative values from stdin
-RAW_COST=$(echo "$INPUT" | jq -r '.cost.total_cost_usd // 0')
-RAW_LINES_ADDED=$(echo "$INPUT" | jq -r '.cost.total_lines_added // 0')
-RAW_LINES_REMOVED=$(echo "$INPUT" | jq -r '.cost.total_lines_removed // 0')
+# Detect process restart: cost decreased from previous invocation
+SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty')
+IS_RESTART="0"
+if [ -n "$PREV_RAW_COST" ] && [ "$PREV_RAW_COST" != "0" ]; then
+    IS_RESTART=$(jq -n --argjson a "$COST" --argjson b "$PREV_RAW_COST" 'if $a < $b then 1 else 0 end' 2>/dev/null || echo "0")
+fi
+if [ "$IS_RESTART" = "1" ]; then
+    ACCUMULATED_TOKENS=0
+    PREV_RAW_TOTAL=0
+fi
 
-# Detect session change and update baseline
+# Detect /clear (session_id changed): reset raw tracking baseline
 if [ -n "$SESSION_ID" ] && [ "$SESSION_ID" != "$PREV_SESSION_ID" ]; then
-    BASELINE_COST="$RAW_COST"
-    BASELINE_LINES_ADDED="$RAW_LINES_ADDED"
-    BASELINE_LINES_REMOVED="$RAW_LINES_REMOVED"
+    PREV_RAW_TOTAL=0
 fi
 
-# Save current session state
-if [ -n "$SESSION_ID" ]; then
-    printf '%s\n%s\n%s\n%s\n' "$SESSION_ID" "$BASELINE_COST" "$BASELINE_LINES_ADDED" "$BASELINE_LINES_REMOVED" > "$SESSION_FILE" 2>/dev/null
+# Detect new API call(s) and accumulate tokens
+if [ "$RAW_TOTAL" -ne "$PREV_RAW_TOTAL" ] 2>/dev/null; then
+    RAW_DELTA=$((RAW_TOTAL - PREV_RAW_TOTAL))
+    CALL_NON_CACHED=$((CALL_INPUT + CALL_OUTPUT))
+    EXTRA=0
+    if [ "$RAW_DELTA" -gt "$CALL_NON_CACHED" ] && [ "$CALL_NON_CACHED" -gt 0 ]; then
+        EXTRA=$((RAW_DELTA - CALL_NON_CACHED))
+    fi
+    ACCUMULATED_TOKENS=$((ACCUMULATED_TOKENS + CALL_TOTAL + EXTRA))
+    PREV_RAW_TOTAL=$RAW_TOTAL
 fi
 
-# Calculate session-relative cost and lines (clamped to >= 0)
-COST=$(echo "$RAW_COST - $BASELINE_COST" | bc 2>/dev/null || echo "0")
-if echo "$COST < 0" | bc -l 2>/dev/null | grep -q '^1'; then
-    COST="0"
-fi
-COST_FORMATTED=$(printf "%.2f" "$COST")
-LINES_ADDED=$((RAW_LINES_ADDED - BASELINE_LINES_ADDED))
-LINES_REMOVED=$((RAW_LINES_REMOVED - BASELINE_LINES_REMOVED))
-if [ "$LINES_ADDED" -lt 0 ]; then LINES_ADDED=0; fi
-if [ "$LINES_REMOVED" -lt 0 ]; then LINES_REMOVED=0; fi
+TOTAL_TOKENS=$ACCUMULATED_TOKENS
 
-# === TOKEN USAGE FROM CONTEXT WINDOW ===
-# Use context_window fields from stdin JSON (resets properly on /clear)
-TOTAL_INPUT_TOKENS=$(echo "$INPUT" | jq -r '.context_window.total_input_tokens // 0')
-TOTAL_OUTPUT_TOKENS=$(echo "$INPUT" | jq -r '.context_window.total_output_tokens // 0')
-TOTAL_TOKENS=$((TOTAL_INPUT_TOKENS + TOTAL_OUTPUT_TOKENS))
+# Save token tracking state
+printf '%s\n%s\n%s\n%s\n' "$SESSION_ID" "$PREV_RAW_TOTAL" "$ACCUMULATED_TOKENS" "$COST" > "$SESSION_FILE" 2>/dev/null
 
 # Context length from current_usage (most recent message's context size)
-CONTEXT_LENGTH=$(echo "$INPUT" | jq -r '
-    ((.context_window.current_usage.input_tokens // 0) +
-     (.context_window.current_usage.cache_read_input_tokens // 0) +
-     (.context_window.current_usage.cache_creation_input_tokens // 0))' 2>/dev/null)
-
-if [ -z "$CONTEXT_LENGTH" ] || [ "$CONTEXT_LENGTH" = "null" ]; then
-    CONTEXT_LENGTH=0
-fi
-
+CONTEXT_LENGTH=$((CALL_INPUT + CALL_CACHE_READ + CALL_CACHE_CREATE))
 
 # Format tokens (k for thousands, M for millions)
 format_tokens() {

--- a/src/cli/features/claude-code/statusline/docs.md
+++ b/src/cli/features/claude-code/statusline/docs.md
@@ -5,7 +5,7 @@ Path: @/src/cli/features/claude-code/statusline
 ### Overview
 
 - Installs a custom status line script into Claude Code that displays git branch, session cost, token usage, context length, and Nori branding
-- Handles session reset: token/context counters reset automatically on `/clear`; cost/lines counters reset via session-id tracking
+- Distinguishes between two session scopes: **user session** (opening Claude Code) where cost, tokens, and lines accumulate, and **Claude session** (`/clear` boundary) where only context resets
 
 ### How it fits into the larger codebase
 
@@ -16,13 +16,13 @@ Path: @/src/cli/features/claude-code/statusline
 ### Core Implementation
 
 - `loader.ts` copies `config/nori-statusline.sh` to `~/.claude/nori-statusline.sh`, makes it executable, and sets `settings.statusLine` in `~/.claude/settings.json` to `type: "command"` pointing at the copied script
-- Token and context data come from structured `context_window` fields in the stdin JSON that Claude Code passes to the script (not from transcript file parsing)
-- Cost and lines data come from `cost` fields in stdin JSON, with session-relative deltas tracked via `/tmp/nori-statusline-session-<cwd-hash>` files
+- Token and context data come from `context_window` fields in the stdin JSON that Claude Code passes to the script; tokens are accumulated by the script itself in a session file to include cached tokens and persist across `/clear`
+- Cost and lines come directly from `cost.total_cost_usd`, `cost.total_lines_added`, `cost.total_lines_removed` in stdin JSON -- these are already cumulative per process, so no baseline subtraction is needed
 
 ### Things to Know
 
 - The loader gracefully skips configuration if the source script is not found in the build output
 - The shell script depends on `jq`; if missing, it displays a warning instead of the full status line
-- Session tracking files in `/tmp/` allow cost/lines to reset on `/clear` without requiring Claude Code to reset those cumulative fields itself
+- Session tracking files in `/tmp/` store token accumulation state so that token counts include cached tokens (which are invisible in `total_input_tokens`) and persist across `/clear` boundaries
 
 Created and maintained by Nori.

--- a/src/cli/features/claude-code/statusline/loader.test.ts
+++ b/src/cli/features/claude-code/statusline/loader.test.ts
@@ -434,7 +434,7 @@ describe("statuslineLoader", () => {
       }
     });
 
-    it("should display token count from context_window fields in stdin JSON", async () => {
+    it("should display token count including cached tokens from current_usage", async () => {
       const config: Config = { installDir: claudeDir };
 
       await statuslineLoader.run({ agent: {} as any, config });
@@ -453,8 +453,14 @@ describe("statuslineLoader", () => {
           total_lines_removed: 5,
         },
         context_window: {
-          total_input_tokens: 25000,
-          total_output_tokens: 5000,
+          total_input_tokens: 500,
+          total_output_tokens: 200,
+          current_usage: {
+            input_tokens: 500,
+            cache_read_input_tokens: 20000,
+            cache_creation_input_tokens: 5000,
+            output_tokens: 200,
+          },
         },
         transcript_path: "",
       });
@@ -464,8 +470,8 @@ describe("statuslineLoader", () => {
         encoding: "utf-8",
       });
 
-      // 25000 + 5000 = 30000 = 30k
-      expect(output).toContain("Tokens: 30.0k");
+      // Tokens should include cached: 500 + 20000 + 5000 + 200 = 25700 = 25.7k
+      expect(output).toContain("Tokens: 25.7k");
     });
 
     it("should display context length from context_window.current_usage fields", async () => {
@@ -538,7 +544,7 @@ describe("statuslineLoader", () => {
       expect(output).toContain("Context: 0");
     });
 
-    it("should reset cost and lines when session_id changes", async () => {
+    it("should NOT reset cost and lines when session_id changes", async () => {
       const config: Config = { installDir: claudeDir };
 
       await statuslineLoader.run({ agent: {} as any, config });
@@ -561,6 +567,12 @@ describe("statuslineLoader", () => {
         context_window: {
           total_input_tokens: 100000,
           total_output_tokens: 20000,
+          current_usage: {
+            input_tokens: 1000,
+            cache_read_input_tokens: 20000,
+            cache_creation_input_tokens: 0,
+            output_tokens: 500,
+          },
         },
         transcript_path: "",
       });
@@ -570,7 +582,7 @@ describe("statuslineLoader", () => {
         encoding: "utf-8",
       });
 
-      // Second session (after /clear): cost in stdin is cumulative but session_id changed
+      // Second session (after /clear): cost in stdin is cumulative, session_id changed
       const secondSessionInput = JSON.stringify({
         cwd: tempDir,
         session_id: "session-2",
@@ -591,13 +603,13 @@ describe("statuslineLoader", () => {
         encoding: "utf-8",
       });
 
-      // Cost should show $0.00 because session changed and baseline was $2.50
-      expect(output).toContain("Cost: $0.00");
-      // Lines should show +0/-0
-      expect(output).toContain("Lines: +0/-0");
+      // Cost should still show $2.50 (cumulative across user session)
+      expect(output).toContain("Cost: $2.50");
+      // Lines should still show +50/-20
+      expect(output).toContain("Lines: +50/-20");
     });
 
-    it("should accumulate cost within the same session", async () => {
+    it("should persist tokens across /clear (session_id change)", async () => {
       const config: Config = { installDir: claudeDir };
 
       await statuslineLoader.run({ agent: {} as any, config });
@@ -608,29 +620,173 @@ describe("statuslineLoader", () => {
 
       const { execSync } = await import("child_process");
 
-      // Ensure clean session state
-      const cleanSessionInput = JSON.stringify({
+      // First session: one API call with 25k total tokens (including cache)
+      const firstSessionInput = JSON.stringify({
         cwd: tempDir,
-        session_id: "session-accumulate",
+        session_id: "session-persist-1",
         cost: {
-          total_cost_usd: 0,
-          total_lines_added: 0,
-          total_lines_removed: 0,
+          total_cost_usd: 1.0,
+          total_lines_added: 10,
+          total_lines_removed: 5,
         },
         context_window: {
-          total_input_tokens: 0,
-          total_output_tokens: 0,
+          total_input_tokens: 500,
+          total_output_tokens: 200,
+          current_usage: {
+            input_tokens: 500,
+            cache_read_input_tokens: 20000,
+            cache_creation_input_tokens: 5000,
+            output_tokens: 200,
+          },
         },
         transcript_path: "",
       });
 
       execSync(statusLineCommand, {
-        input: cleanSessionInput,
+        input: firstSessionInput,
         encoding: "utf-8",
       });
 
-      // Same session, cost grows
-      const laterInput = JSON.stringify({
+      // After /clear: new session, new API call with 22k total tokens
+      const secondSessionInput = JSON.stringify({
+        cwd: tempDir,
+        session_id: "session-persist-2",
+        cost: {
+          total_cost_usd: 1.5,
+          total_lines_added: 15,
+          total_lines_removed: 8,
+        },
+        context_window: {
+          total_input_tokens: 300,
+          total_output_tokens: 100,
+          current_usage: {
+            input_tokens: 300,
+            cache_read_input_tokens: 20000,
+            cache_creation_input_tokens: 2000,
+            output_tokens: 100,
+          },
+        },
+        transcript_path: "",
+      });
+
+      const output = execSync(statusLineCommand, {
+        input: secondSessionInput,
+        encoding: "utf-8",
+      });
+
+      // Tokens should be cumulative: 25700 + 22400 = 48100 = 48.1k
+      expect(output).toContain("Tokens: 48.1k");
+    });
+
+    it("should reset tokens on process restart (cost decreases)", async () => {
+      const config: Config = { installDir: claudeDir };
+
+      await statuslineLoader.run({ agent: {} as any, config });
+
+      const content = await fs.readFile(settingsPath, "utf-8");
+      const settings = JSON.parse(content);
+      const statusLineCommand = settings.statusLine.command;
+
+      const { execSync } = await import("child_process");
+
+      // First process: accumulate tokens with cost $2.00
+      const firstProcessInput = JSON.stringify({
+        cwd: tempDir,
+        session_id: "process-1-session",
+        cost: {
+          total_cost_usd: 2.0,
+          total_lines_added: 100,
+          total_lines_removed: 50,
+        },
+        context_window: {
+          total_input_tokens: 1000,
+          total_output_tokens: 500,
+          current_usage: {
+            input_tokens: 1000,
+            cache_read_input_tokens: 20000,
+            cache_creation_input_tokens: 5000,
+            output_tokens: 500,
+          },
+        },
+        transcript_path: "",
+      });
+
+      execSync(statusLineCommand, {
+        input: firstProcessInput,
+        encoding: "utf-8",
+      });
+
+      // New process (restart): cost starts low again, new session_id
+      const newProcessInput = JSON.stringify({
+        cwd: tempDir,
+        session_id: "process-2-session",
+        cost: {
+          total_cost_usd: 0.05,
+          total_lines_added: 5,
+          total_lines_removed: 2,
+        },
+        context_window: {
+          total_input_tokens: 200,
+          total_output_tokens: 100,
+          current_usage: {
+            input_tokens: 200,
+            cache_read_input_tokens: 20000,
+            cache_creation_input_tokens: 3000,
+            output_tokens: 100,
+          },
+        },
+        transcript_path: "",
+      });
+
+      const output = execSync(statusLineCommand, {
+        input: newProcessInput,
+        encoding: "utf-8",
+      });
+
+      // Tokens should reset: only new process tokens = 200 + 20000 + 3000 + 100 = 23300 = 23.3k
+      expect(output).toContain("Tokens: 23.3k");
+    });
+
+    it("should accumulate tokens across multiple API calls within the same session", async () => {
+      const config: Config = { installDir: claudeDir };
+
+      await statuslineLoader.run({ agent: {} as any, config });
+
+      const content = await fs.readFile(settingsPath, "utf-8");
+      const settings = JSON.parse(content);
+      const statusLineCommand = settings.statusLine.command;
+
+      const { execSync } = await import("child_process");
+
+      // First API call
+      const firstCallInput = JSON.stringify({
+        cwd: tempDir,
+        session_id: "session-accumulate",
+        cost: {
+          total_cost_usd: 0.5,
+          total_lines_added: 10,
+          total_lines_removed: 5,
+        },
+        context_window: {
+          total_input_tokens: 500,
+          total_output_tokens: 200,
+          current_usage: {
+            input_tokens: 500,
+            cache_read_input_tokens: 20000,
+            cache_creation_input_tokens: 5000,
+            output_tokens: 200,
+          },
+        },
+        transcript_path: "",
+      });
+
+      execSync(statusLineCommand, {
+        input: firstCallInput,
+        encoding: "utf-8",
+      });
+
+      // Second API call (same session, raw totals grew)
+      const secondCallInput = JSON.stringify({
         cwd: tempDir,
         session_id: "session-accumulate",
         cost: {
@@ -639,20 +795,78 @@ describe("statuslineLoader", () => {
           total_lines_removed: 10,
         },
         context_window: {
-          total_input_tokens: 50000,
-          total_output_tokens: 10000,
+          total_input_tokens: 1000,
+          total_output_tokens: 600,
+          current_usage: {
+            input_tokens: 500,
+            cache_read_input_tokens: 20000,
+            cache_creation_input_tokens: 0,
+            output_tokens: 400,
+          },
         },
         transcript_path: "",
       });
 
       const output = execSync(statusLineCommand, {
-        input: laterInput,
+        input: secondCallInput,
         encoding: "utf-8",
       });
 
-      // Cost should show $1.75 (same session, no reset)
+      // First call: 500 + 20000 + 5000 + 200 = 25700
+      // Second call: 500 + 20000 + 0 + 400 = 20900
+      // Total: 46600 = 46.6k
+      expect(output).toContain("Tokens: 46.6k");
+      // Cost should show raw cumulative $1.75
       expect(output).toContain("Cost: $1.75");
       expect(output).toContain("Lines: +30/-10");
+    });
+
+    it("should not double-count tokens when invoked repeatedly with same data", async () => {
+      const config: Config = { installDir: claudeDir };
+
+      await statuslineLoader.run({ agent: {} as any, config });
+
+      const content = await fs.readFile(settingsPath, "utf-8");
+      const settings = JSON.parse(content);
+      const statusLineCommand = settings.statusLine.command;
+
+      const { execSync } = await import("child_process");
+
+      const sameInput = JSON.stringify({
+        cwd: tempDir,
+        session_id: "session-no-double",
+        cost: {
+          total_cost_usd: 0.5,
+          total_lines_added: 10,
+          total_lines_removed: 5,
+        },
+        context_window: {
+          total_input_tokens: 500,
+          total_output_tokens: 200,
+          current_usage: {
+            input_tokens: 500,
+            cache_read_input_tokens: 20000,
+            cache_creation_input_tokens: 5000,
+            output_tokens: 200,
+          },
+        },
+        transcript_path: "",
+      });
+
+      // First invocation
+      execSync(statusLineCommand, {
+        input: sameInput,
+        encoding: "utf-8",
+      });
+
+      // Second invocation with identical data (timer-driven refresh, no new API call)
+      const output = execSync(statusLineCommand, {
+        input: sameInput,
+        encoding: "utf-8",
+      });
+
+      // Should still show 25.7k (not 51.4k from double-counting)
+      expect(output).toContain("Tokens: 25.7k");
     });
 
     it("should display jq missing warning when jq is not available", async () => {


### PR DESCRIPTION
## Summary
🤖 Generated with [Nori](https://www.npmjs.com/package/nori-ai)

- **Tokens now include cached tokens**: Uses `current_usage` fields (input_tokens + cache_read + cache_creation + output_tokens) instead of `total_input_tokens + total_output_tokens` which excluded cached system prompt tokens (~27k invisible tokens)
- **Tokens/cost/lines persist across `/clear`**: Tokens are self-accumulated in a session file across Claude sessions; cost and lines display raw cumulative values (no more baseline subtraction that zeroed them on `/clear`)
- **Process restart detection**: Uses cost-decrease heuristic via `jq` to reset token accumulators when a new Claude Code process starts

## Test Plan
- [x] 20 tests pass (6 new/updated tests for token caching, accumulation, /clear persistence, process restart, no-double-counting)
- [x] 1893 total tests pass
- [x] Format and lint clean
- [ ] Manual verification: run Claude Code, check statusline shows tokens/cost/lines, run /clear, verify tokens/cost persist and context resets

Share Nori with your team: https://www.npmjs.com/package/nori-skillsets