### PR TITLE
chore(logger): tweak comment wording

### DIFF
--- a/src/cli/logger.ts
+++ b/src/cli/logger.ts
@@ -24,7 +24,7 @@ const levels = {
   debug: 4,
 };
 
-// ANSI color codes for console output
+// ANSI color codes for terminal output
 const colors = {
   RED: "\x1b[0;31m",
   GREEN: "\x1b[0;32m",


### PR DESCRIPTION
## Summary
- Rephrase ANSI color codes comment in `src/cli/logger.ts` from "console output" to "terminal output".
- No behavioral change.

## Test plan
- [x] `npm run build`
- [x] `npm run format`
- [x] `npm run lint` (eslint + tsc --noEmit + prettier check all pass)