### PR TITLE
(fix) Backup existing status bar if one exists

### DIFF
--- a/src/cli/features/claude-code/statusline/loader.test.ts
+++ b/src/cli/features/claude-code/statusline/loader.test.ts
@@ -9,7 +9,23 @@ import * as path from "path";
 
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 
+import { confirmAction } from "@/cli/prompts/confirm.js";
+
 import type { Config } from "@/cli/config.js";
+
+vi.mock("@clack/prompts", () => ({
+  log: {
+    info: vi.fn(),
+    success: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    message: vi.fn(),
+  },
+}));
+
+vi.mock("@/cli/prompts/confirm.js", () => ({
+  confirmAction: vi.fn(),
+}));
 
 // Mock the env module to use temp directories
 let mockClaudeDir: string;
@@ -144,6 +160,133 @@ describe("statuslineLoader", () => {
       // Verify statusLine still exists
       expect(settings.statusLine).toBeDefined();
       expect(settings.statusLine.type).toBe("command");
+    });
+  });
+
+  describe("existing statusLine backup and confirmation", () => {
+    it("should prompt and replace when user confirms in TTY mode", async () => {
+      const config: Config = { installDir: tempDir };
+      const foreignCommand = "/usr/local/bin/other-statusline.sh";
+
+      await fs.writeFile(
+        settingsPath,
+        JSON.stringify({
+          statusLine: { type: "command", command: foreignCommand, padding: 0 },
+        }),
+      );
+
+      const originalIsTTY = process.stdin.isTTY;
+      process.stdin.isTTY = true;
+      vi.mocked(confirmAction).mockResolvedValueOnce(true);
+
+      try {
+        await statuslineLoader.run({ agent: {} as any, config });
+      } finally {
+        process.stdin.isTTY = originalIsTTY;
+      }
+
+      // Backup should exist with original config
+      const backupPath = path.join(claudeDir, ".nori-statusline-backup.json");
+      const backup = JSON.parse(await fs.readFile(backupPath, "utf-8"));
+      expect(backup.command).toBe(foreignCommand);
+
+      // Settings should now point to nori script
+      const settings = JSON.parse(await fs.readFile(settingsPath, "utf-8"));
+      expect(settings.statusLine.command).toContain("nori-statusline.sh");
+    });
+
+    it("should prompt and abort when user declines in TTY mode", async () => {
+      const config: Config = { installDir: tempDir };
+      const foreignCommand = "/usr/local/bin/other-statusline.sh";
+
+      await fs.writeFile(
+        settingsPath,
+        JSON.stringify({
+          statusLine: { type: "command", command: foreignCommand, padding: 0 },
+        }),
+      );
+
+      const originalIsTTY = process.stdin.isTTY;
+      process.stdin.isTTY = true;
+      vi.mocked(confirmAction).mockResolvedValueOnce(false);
+
+      try {
+        const result = await statuslineLoader.run({
+          agent: {} as any,
+          config,
+        });
+        expect(result).toBeUndefined();
+      } finally {
+        process.stdin.isTTY = originalIsTTY;
+      }
+
+      // Settings should be unchanged
+      const settings = JSON.parse(await fs.readFile(settingsPath, "utf-8"));
+      expect(settings.statusLine.command).toBe(foreignCommand);
+
+      // Script should NOT have been copied
+      const scriptExists = await fs
+        .access(path.join(claudeDir, "nori-statusline.sh"))
+        .then(() => true)
+        .catch(() => false);
+      expect(scriptExists).toBe(false);
+    });
+
+    it("should replace without prompting in non-TTY mode", async () => {
+      const config: Config = { installDir: tempDir };
+      const foreignCommand = "/usr/local/bin/other-statusline.sh";
+
+      await fs.writeFile(
+        settingsPath,
+        JSON.stringify({
+          statusLine: { type: "command", command: foreignCommand, padding: 0 },
+        }),
+      );
+
+      const originalIsTTY = process.stdin.isTTY;
+      process.stdin.isTTY = false;
+
+      try {
+        await statuslineLoader.run({ agent: {} as any, config });
+      } finally {
+        process.stdin.isTTY = originalIsTTY;
+      }
+
+      // Backup should exist
+      const backupPath = path.join(claudeDir, ".nori-statusline-backup.json");
+      const backup = JSON.parse(await fs.readFile(backupPath, "utf-8"));
+      expect(backup.command).toBe(foreignCommand);
+
+      // Settings should now point to nori script
+      const settings = JSON.parse(await fs.readFile(settingsPath, "utf-8"));
+      expect(settings.statusLine.command).toContain("nori-statusline.sh");
+
+      // confirm should NOT have been called
+      expect(confirmAction).not.toHaveBeenCalled();
+    });
+
+    it("should not prompt or backup when existing command matches nori script", async () => {
+      const config: Config = { installDir: tempDir };
+      const noriCommand = path.join(claudeDir, "nori-statusline.sh");
+
+      await fs.writeFile(
+        settingsPath,
+        JSON.stringify({
+          statusLine: { type: "command", command: noriCommand, padding: 0 },
+        }),
+      );
+
+      await statuslineLoader.run({ agent: {} as any, config });
+
+      // No backup should be created
+      const backupExists = await fs
+        .access(path.join(claudeDir, ".nori-statusline-backup.json"))
+        .then(() => true)
+        .catch(() => false);
+      expect(backupExists).toBe(false);
+
+      // confirm should NOT have been called
+      expect(confirmAction).not.toHaveBeenCalled();
     });
   });
 
@@ -995,6 +1138,85 @@ ${scriptContent}
       await expect(
         statuslineLoader.uninstall!({ agent: {} as any, installDir: tempDir }),
       ).resolves.not.toThrow();
+    });
+
+    it("should restore previous statusLine from backup when backup exists", async () => {
+      const originalStatusLine = {
+        type: "command",
+        command: "/usr/local/bin/my-custom-statusline.sh",
+        padding: 1,
+      };
+
+      // Write backup file
+      const backupPath = path.join(claudeDir, ".nori-statusline-backup.json");
+      await fs.writeFile(
+        backupPath,
+        JSON.stringify(originalStatusLine, null, 2),
+      );
+
+      // Write current settings with nori statusLine
+      const settings = {
+        $schema: "https://json.schemastore.org/claude-code-settings.json",
+        statusLine: {
+          type: "command",
+          command: path.join(claudeDir, "nori-statusline.sh"),
+          padding: 0,
+        },
+        someOtherSetting: "value",
+      };
+      await fs.writeFile(settingsPath, JSON.stringify(settings, null, 2));
+
+      // Create nori-statusline.sh so it can be cleaned up
+      const statuslineScript = path.join(claudeDir, "nori-statusline.sh");
+      await fs.writeFile(statuslineScript, "#!/bin/bash\necho test");
+
+      await statuslineLoader.uninstall!({
+        agent: {} as any,
+        installDir: tempDir,
+      });
+
+      // Settings should have the original statusLine restored
+      const content = await fs.readFile(settingsPath, "utf-8");
+      const result = JSON.parse(content);
+      expect(result.statusLine).toEqual(originalStatusLine);
+      expect(result.someOtherSetting).toBe("value");
+
+      // Backup file should be cleaned up
+      const backupExists = await fs
+        .access(backupPath)
+        .then(() => true)
+        .catch(() => false);
+      expect(backupExists).toBe(false);
+
+      // nori script should still be deleted
+      const scriptExists = await fs
+        .access(statuslineScript)
+        .then(() => true)
+        .catch(() => false);
+      expect(scriptExists).toBe(false);
+    });
+
+    it("should remove statusLine when no backup exists", async () => {
+      const settings = {
+        $schema: "https://json.schemastore.org/claude-code-settings.json",
+        statusLine: {
+          type: "command",
+          command: path.join(claudeDir, "nori-statusline.sh"),
+          padding: 0,
+        },
+        someOtherSetting: "value",
+      };
+      await fs.writeFile(settingsPath, JSON.stringify(settings, null, 2));
+
+      await statuslineLoader.uninstall!({
+        agent: {} as any,
+        installDir: tempDir,
+      });
+
+      const content = await fs.readFile(settingsPath, "utf-8");
+      const result = JSON.parse(content);
+      expect(result.statusLine).toBeUndefined();
+      expect(result.someOtherSetting).toBe("value");
     });
   });
 });

--- a/src/cli/features/claude-code/statusline/loader.test.ts
+++ b/src/cli/features/claude-code/statusline/loader.test.ts
@@ -230,6 +230,13 @@ describe("statuslineLoader", () => {
         .then(() => true)
         .catch(() => false);
       expect(scriptExists).toBe(false);
+
+      // Backup should NOT have been created
+      const backupExists = await fs
+        .access(path.join(claudeDir, ".nori-statusline-backup.json"))
+        .then(() => true)
+        .catch(() => false);
+      expect(backupExists).toBe(false);
     });
 
     it("should replace without prompting in non-TTY mode", async () => {

--- a/src/cli/features/claude-code/statusline/loader.test.ts
+++ b/src/cli/features/claude-code/statusline/loader.test.ts
@@ -1203,6 +1203,47 @@ ${scriptContent}
       expect(scriptExists).toBe(false);
     });
 
+    it("should warn and fall back to removal when backup file is corrupt", async () => {
+      const { log } = await import("@clack/prompts");
+
+      const backupPath = path.join(claudeDir, ".nori-statusline-backup.json");
+      await fs.writeFile(backupPath, "not valid json {{{");
+
+      const settings = {
+        $schema: "https://json.schemastore.org/claude-code-settings.json",
+        statusLine: {
+          type: "command",
+          command: path.join(claudeDir, "nori-statusline.sh"),
+          padding: 0,
+        },
+        someOtherSetting: "value",
+      };
+      await fs.writeFile(settingsPath, JSON.stringify(settings, null, 2));
+
+      const statuslineScript = path.join(claudeDir, "nori-statusline.sh");
+      await fs.writeFile(statuslineScript, "#!/bin/bash\necho test");
+
+      await statuslineLoader.uninstall!({
+        agent: {} as any,
+        installDir: tempDir,
+      });
+
+      expect(log.warn).toHaveBeenCalledWith(
+        expect.stringContaining("Failed to read status line backup"),
+      );
+
+      const content = await fs.readFile(settingsPath, "utf-8");
+      const result = JSON.parse(content);
+      expect(result.statusLine).toBeUndefined();
+      expect(result.someOtherSetting).toBe("value");
+
+      const backupExists = await fs
+        .access(backupPath)
+        .then(() => true)
+        .catch(() => false);
+      expect(backupExists).toBe(false);
+    });
+
     it("should remove statusLine when no backup exists", async () => {
       const settings = {
         $schema: "https://json.schemastore.org/claude-code-settings.json",

--- a/src/cli/features/claude-code/statusline/loader.ts
+++ b/src/cli/features/claude-code/statusline/loader.ts
@@ -25,15 +25,14 @@ const __dirname = path.dirname(__filename);
 
 /**
  * Configure status line to display git branch, session cost, token usage, and Nori branding
- * @param args - Configuration arguments
- * @param args.config - Runtime configuration
+ * @param _args - Configuration arguments
+ * @param _args.config - Runtime configuration
  *
  * @returns Label for the settings note, or void on failure
  */
-const configureStatusLine = async (args: {
+const configureStatusLine = async (_args: {
   config: Config;
 }): Promise<string | void> => {
-  const { config: _config } = args;
   const claudeDir = getClaudeHomeDir();
   const claudeSettingsFile = getClaudeHomeSettingsFile();
 
@@ -68,22 +67,25 @@ const configureStatusLine = async (args: {
   const existing = settings.statusLine;
   if (existing && existing.command !== destScript) {
     const backupPath = path.join(claudeDir, ".nori-statusline-backup.json");
+
+    if (process.stdin.isTTY) {
+      const displayCmd = existing.command ?? JSON.stringify(existing);
+      const shouldReplace = await confirmAction({
+        message: `Your Claude Code status line is currently set to: ${displayCmd}\nReplace with Nori status line? (original will be backed up to ${backupPath})`,
+      });
+      if (!shouldReplace) {
+        log.info(`Keeping existing status line configuration`);
+        return;
+      }
+    }
+
     await fs.mkdir(claudeDir, { recursive: true });
     await fs.writeFile(
       backupPath,
       JSON.stringify(settings.statusLine, null, 2),
     );
 
-    if (process.stdin.isTTY) {
-      const displayCmd = existing.command ?? JSON.stringify(existing);
-      const shouldReplace = await confirmAction({
-        message: `Your Claude Code status line is currently set to: ${displayCmd}\nReplace with Nori status line? (backed up to ${backupPath})`,
-      });
-      if (!shouldReplace) {
-        log.info(`Keeping existing status line configuration`);
-        return;
-      }
-    } else {
+    if (!process.stdin.isTTY) {
       log.info(`Backed up existing status line to ${backupPath}`);
     }
   }
@@ -146,7 +148,7 @@ const restoreStatusLine = async (args: {
 export const statuslineLoader: AgentLoader = {
   name: "statusline",
   description: "Claude Code status line configuration",
-  managedFiles: ["nori-statusline.sh"],
+  managedFiles: ["nori-statusline.sh", "settings.json"],
   run: async ({ config }) => {
     return configureStatusLine({ config });
   },

--- a/src/cli/features/claude-code/statusline/loader.ts
+++ b/src/cli/features/claude-code/statusline/loader.ts
@@ -120,7 +120,16 @@ const restoreStatusLine = async (args: {
   try {
     const content = await fs.readFile(backupPath, "utf-8");
     backup = JSON.parse(content);
-  } catch {
+  } catch (err) {
+    const isNotFound =
+      err instanceof Error &&
+      "code" in err &&
+      (err as NodeJS.ErrnoException).code === "ENOENT";
+    if (!isNotFound) {
+      log.warn(
+        `Failed to read status line backup at ${backupPath}, removing status line instead`,
+      );
+    }
     return false;
   }
 
@@ -148,7 +157,11 @@ const restoreStatusLine = async (args: {
 export const statuslineLoader: AgentLoader = {
   name: "statusline",
   description: "Claude Code status line configuration",
-  managedFiles: ["nori-statusline.sh", "settings.json"],
+  managedFiles: [
+    "nori-statusline.sh",
+    "settings.json",
+    ".nori-statusline-backup.json",
+  ],
   run: async ({ config }) => {
     return configureStatusLine({ config });
   },
@@ -167,6 +180,7 @@ export const statuslineLoader: AgentLoader = {
         settingsFile: claudeSettingsFile,
         keys: ["statusLine"],
       });
+      await fs.rm(backupPath, { force: true });
     }
 
     const statuslineScript = path.join(claudeDir, "nori-statusline.sh");

--- a/src/cli/features/claude-code/statusline/loader.ts
+++ b/src/cli/features/claude-code/statusline/loader.ts
@@ -14,6 +14,7 @@ import {
   getClaudeHomeSettingsFile,
   removeSettingsKeys,
 } from "@/cli/features/claude-code/paths.js";
+import { confirmAction } from "@/cli/prompts/confirm.js";
 
 import type { Config } from "@/cli/config.js";
 import type { AgentLoader } from "@/cli/features/agentRegistry.js";
@@ -52,16 +53,7 @@ const configureStatusLine = async (args: {
     return;
   }
 
-  // Create .claude directory if it doesn't exist
-  await fs.mkdir(claudeDir, { recursive: true });
-
-  // Copy script to .claude directory
-  await fs.copyFile(sourceScript, destScript);
-
-  // Make script executable
-  await fs.chmod(destScript, 0o755);
-
-  // Initialize settings file if it doesn't exist
+  // Read existing settings before making any filesystem changes
   let settings: any = {};
   try {
     const content = await fs.readFile(claudeSettingsFile, "utf-8");
@@ -71,6 +63,39 @@ const configureStatusLine = async (args: {
       $schema: "https://json.schemastore.org/claude-code-settings.json",
     };
   }
+
+  // Check for existing statusLine configuration
+  const existing = settings.statusLine;
+  if (existing && existing.command !== destScript) {
+    const backupPath = path.join(claudeDir, ".nori-statusline-backup.json");
+    await fs.mkdir(claudeDir, { recursive: true });
+    await fs.writeFile(
+      backupPath,
+      JSON.stringify(settings.statusLine, null, 2),
+    );
+
+    if (process.stdin.isTTY) {
+      const displayCmd = existing.command ?? JSON.stringify(existing);
+      const shouldReplace = await confirmAction({
+        message: `Your Claude Code status line is currently set to: ${displayCmd}\nReplace with Nori status line? (backed up to ${backupPath})`,
+      });
+      if (!shouldReplace) {
+        log.info(`Keeping existing status line configuration`);
+        return;
+      }
+    } else {
+      log.info(`Backed up existing status line to ${backupPath}`);
+    }
+  }
+
+  // Create .claude directory if it doesn't exist
+  await fs.mkdir(claudeDir, { recursive: true });
+
+  // Copy script to .claude directory
+  await fs.copyFile(sourceScript, destScript);
+
+  // Make script executable
+  await fs.chmod(destScript, 0o755);
 
   // Add status line configuration pointing to copied script
   settings.statusLine = {
@@ -83,25 +108,66 @@ const configureStatusLine = async (args: {
   return "Status line";
 };
 
+const restoreStatusLine = async (args: {
+  settingsFile: string;
+  backupPath: string;
+}): Promise<boolean> => {
+  const { settingsFile, backupPath } = args;
+
+  let backup: unknown;
+  try {
+    const content = await fs.readFile(backupPath, "utf-8");
+    backup = JSON.parse(content);
+  } catch {
+    return false;
+  }
+
+  let settings: Record<string, unknown>;
+  try {
+    const content = await fs.readFile(settingsFile, "utf-8");
+    settings = JSON.parse(content) as Record<string, unknown>;
+  } catch {
+    settings = {
+      $schema: "https://json.schemastore.org/claude-code-settings.json",
+    };
+  }
+
+  settings.statusLine = backup;
+  await fs.writeFile(settingsFile, JSON.stringify(settings, null, 2));
+  await fs.rm(backupPath, { force: true });
+
+  log.info("Restored previous status line configuration from backup");
+  return true;
+};
+
 /**
  * Statusline feature loader
  */
 export const statuslineLoader: AgentLoader = {
   name: "statusline",
   description: "Claude Code status line configuration",
-  managedFiles: ["nori-statusline.sh", "settings.json"],
+  managedFiles: ["nori-statusline.sh"],
   run: async ({ config }) => {
     return configureStatusLine({ config });
   },
   uninstall: async () => {
-    await removeSettingsKeys({
-      settingsFile: getClaudeHomeSettingsFile(),
-      keys: ["statusLine"],
+    const claudeDir = getClaudeHomeDir();
+    const claudeSettingsFile = getClaudeHomeSettingsFile();
+    const backupPath = path.join(claudeDir, ".nori-statusline-backup.json");
+
+    const restored = await restoreStatusLine({
+      settingsFile: claudeSettingsFile,
+      backupPath,
     });
-    const statuslineScript = path.join(
-      getClaudeHomeDir(),
-      "nori-statusline.sh",
-    );
+
+    if (!restored) {
+      await removeSettingsKeys({
+        settingsFile: claudeSettingsFile,
+        keys: ["statusLine"],
+      });
+    }
+
+    const statuslineScript = path.join(claudeDir, "nori-statusline.sh");
     await fs.rm(statuslineScript, { force: true });
   },
 };


### PR DESCRIPTION
  ## Summary
  - Amol deleted my status bar and I was sad
  - Backs up any existing (non-Nori) status line config before overwriting, and restores it on uninstall
  - Prompts for confirmation in interactive (TTY) mode; silently backs up in non-TTY/CI
  - Falls back to clean removal if backup is missing or corrupt

  ## Test plan
  - [x] All 31 tests pass, including 7 new cases covering:
    - TTY confirm/decline prompt behavior
    - Non-TTY silent backup
    - Skip when existing config is already Nori
    - Restore from backup on uninstall
    - Corrupt backup fallback to removal
    - No-backup uninstall path

  🤖 Generated with [Claude Code](https://claude.com/claude-code)