### PR TITLE
fix(commit-author): use real newlines and skip when Nori attribution present

### DIFF
--- a/src/cli/features/claude-code/hooks/config/commit-author.test.ts
+++ b/src/cli/features/claude-code/hooks/config/commit-author.test.ts
@@ -156,5 +156,44 @@ EOF
       expect(result).toContain("Add new feature");
       expect(result).toContain("Co-Authored-By: Nori <contact@tilework.tech>");
     });
+
+    it("should use real newlines (not literal \\n) between message and attribution in -m form", () => {
+      const result = replaceAttribution({
+        command: 'git commit -m "fix: bug"',
+      });
+
+      // Bash sees the command as-is; for newlines to land in the commit message,
+      // the appended attribution must use real \n characters, not the two-char
+      // sequence backslash-n.
+      expect(result).toContain("fix: bug\n\n🤖 Generated with [Nori]");
+      expect(result).toContain(
+        "\n\nCo-Authored-By: Nori <contact@tilework.tech>",
+      );
+    });
+
+    it("should not double-append attribution in EOF heredoc when Nori attribution already present", () => {
+      const command = `git commit -m "$(cat <<'EOF'
+feat: Add new feature
+
+🤖 Generated with [Nori](https://noriagentic.com)
+
+Co-Authored-By: Nori <contact@tilework.tech>
+EOF
+)"`;
+
+      const result = replaceAttribution({ command });
+
+      const noriCoAuthorCount = (
+        result.match(/Co-Authored-By: Nori <contact@tilework\.tech>/g) ?? []
+      ).length;
+      const noriUrlCount = (
+        result.match(
+          /🤖 Generated with \[Nori\]\(https:\/\/noriagentic\.com\)/g,
+        ) ?? []
+      ).length;
+
+      expect(noriCoAuthorCount).toBe(1);
+      expect(noriUrlCount).toBe(1);
+    });
   });
 });

--- a/src/cli/features/claude-code/hooks/config/commit-author.ts
+++ b/src/cli/features/claude-code/hooks/config/commit-author.ts
@@ -77,6 +77,18 @@ export const replaceAttribution = (args: { command: string }): string => {
     return modifiedCommand;
   }
 
+  // If Nori attribution is already present, leave the command alone.
+  // Otherwise re-runs and amends would duplicate the attribution block.
+  // Use tolerant patterns (case-insensitive, whitespace-flexible) so partial
+  // reformatting doesn't bypass the guard. Either marker is enough.
+  const noriCoAuthorPattern =
+    /Co-Authored-By:\s*Nori\s*<contact@tilework\.tech>/i;
+  const noriUrlPattern =
+    /🤖\s*Generated\s*with\s*\[Nori\]\(https:\/\/noriagentic\.com\)/i;
+  if (noriCoAuthorPattern.test(command) || noriUrlPattern.test(command)) {
+    return command;
+  }
+
   // If no Claude attribution found, we need to add Nori attribution
   // Check if this is a heredoc format (contains EOF)
   if (command.includes("EOF")) {
@@ -89,14 +101,16 @@ export const replaceAttribution = (args: { command: string }): string => {
     return modifiedCommand;
   }
 
-  // For simple -m "message" format, we need to append attribution
-  // Match the message content within quotes
+  // For simple -m "message" format, we need to append attribution.
+  // Use real newlines so bash passes them through as message line breaks;
+  // escaped \\n would land in the commit message as the literal two-char
+  // backslash-n sequence.
   const messagePattern = /(-m|--message)\s+(['"])((?:\\.|(?!\2).)*)\2/;
   const match = command.match(messagePattern);
 
   if (match) {
     const [fullMatch, flag, quote, originalMessage] = match;
-    const newMessage = `${originalMessage}\\n\\n🤖 Generated with [Nori](https://noriagentic.com)\\n\\nCo-Authored-By: Nori <contact@tilework.tech>`;
+    const newMessage = `${originalMessage}\n\n🤖 Generated with [Nori](https://noriagentic.com)\n\nCo-Authored-By: Nori <contact@tilework.tech>`;
     modifiedCommand = command.replace(
       fullMatch,
       `${flag} ${quote}${newMessage}${quote}`,


### PR DESCRIPTION
## Summary
🤖 Generated with [Nori](https://noriagentic.com/)

- The `-m \"message\"` branch of the `commit-author` PreToolUse hook was appending attribution with literal `\n\n` (escaped backslash-n) instead of real newlines, producing one-line mangled commit messages. The EOF heredoc branch was already correct.
- Both branches appended Nori attribution unconditionally, so re-runs and amends produced duplicate `Co-Authored-By` and `🤖 Generated with [Nori]` lines. Added a tolerant early-return guard (case-insensitive, whitespace-flexible regex on either marker) after the Claude→Nori replacement pass.
- Two regression tests added in `commit-author.test.ts`.

## Test Plan
- [x] `just test src/cli/features/claude-code/hooks/config/commit-author.test.ts` (17/17 pass; 2 new)
- [x] Full suite: `just test` (137 files, 2083 tests pass)
- [x] `just lint` (eslint + prettier + tsc all clean)
- [ ] Manual sanity: install the published version and verify a `git commit -m \"...\"` produces a properly newline-separated message
- [ ] Manual sanity: amend a commit that already contains Nori attribution and verify it is not duplicated

Share Nori with your team: https://www.npmjs.com/package/nori-skillsets
🤖 Generated with [Nori](https://noriagentic.com)

Co-Authored-By: Nori <contact@tilework.tech>