### PR TITLE
fix(release): stop create_skillsets_release.py hanging on tag pagination

### DIFF
--- a/scripts/create_skillsets_release.py
+++ b/scripts/create_skillsets_release.py
@@ -147,8 +147,8 @@ def main(argv: list[str]) -> int:
         if args.dry_run:
             print("\n[DRY RUN] Would perform the following:")
             print(f"  1. Create annotated tag {tag_name}")
-            print(f"  2. Push tag to origin")
-            print(f"  3. Trigger skillsets-release workflow")
+            print("  2. Push tag to origin")
+            print("  3. Trigger skillsets-release workflow")
             return 0
 
         print("\nCreating and pushing tag...")
@@ -167,7 +167,7 @@ def main(argv: list[str]) -> int:
             print("  3. Publish to npm with @latest tag")
             print("  4. Create GitHub Release")
         print("")
-        print(f"Monitor progress at:")
+        print("Monitor progress at:")
         print(f"  https://github.com/{REPO}/actions")
         print("=" * 60)
 
@@ -285,27 +285,37 @@ def determine_version(args: argparse.Namespace) -> str:
 
 
 def list_tags() -> list[str]:
-    """List all tags matching TAG_PREFIX, returning version strings."""
-    tags: list[str] = []
-    page = 1
-    while True:
-        try:
-            response = run_gh_api(
-                f"/repos/{REPO}/git/refs/tags?per_page=100&page={page}"
-            )
-            if not isinstance(response, list) or not response:
-                break
-            for ref in response:
-                ref_name = ref.get("ref", "")
-                if ref_name.startswith(f"refs/tags/{TAG_PREFIX}"):
-                    version = ref_name[len(f"refs/tags/{TAG_PREFIX}") :]
-                    tags.append(version)
-            if len(response) < 100:
-                break
-            page += 1
-        except ReleaseError:
-            break
-    return tags
+    """List all tags matching TAG_PREFIX, returning version strings.
+
+    The git/refs/tags endpoint returns up to 1000 matching refs in a single
+    response and ignores per_page/page query parameters. A single request is
+    both correct and necessary: page-based pagination here never terminates
+    (every page returns the full set) and fanning out repeated requests gets
+    us rate limited by GitHub.
+    """
+    try:
+        response = run_gh_api(f"/repos/{REPO}/git/refs/tags")
+    except ReleaseError:
+        return []
+
+    if not isinstance(response, list):
+        return []
+
+    # The endpoint caps at 1000 refs with no Link header, so a full response
+    # means results may be silently truncated and version math would be wrong.
+    if len(response) >= 1000:
+        print(
+            f"WARNING: git/refs/tags returned {len(response)} refs; results may "
+            "be truncated at the API's 1000-ref limit.",
+            file=sys.stderr,
+        )
+
+    prefix = f"refs/tags/{TAG_PREFIX}"
+    return [
+        ref["ref"][len(prefix) :]
+        for ref in response
+        if ref.get("ref", "").startswith(prefix)
+    ]
 
 
 def get_latest_release_version() -> Optional[str]:

--- a/scripts/test_create_skillsets_release.py
+++ b/scripts/test_create_skillsets_release.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Tests for create_skillsets_release.py."""
+
+import importlib.util
+import os
+import unittest
+from unittest import mock
+
+# Load the release script as a module (filename is a valid module name).
+_SPEC = importlib.util.spec_from_file_location(
+    "create_skillsets_release",
+    os.path.join(os.path.dirname(__file__), "create_skillsets_release.py"),
+)
+release = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(release)
+
+
+def _fake_refs(count: int) -> list[dict]:
+    """Build a list of `count` tag refs as the GitHub git/refs/tags API returns them."""
+    refs = [{"ref": f"refs/tags/{release.TAG_PREFIX}0.{i}.0"} for i in range(count)]
+    # A non-matching ref must be filtered out.
+    refs.append({"ref": "refs/tags/some-other-tag"})
+    return refs
+
+
+class ListTagsTest(unittest.TestCase):
+    def test_makes_a_single_api_request_for_a_full_response(self):
+        """The git/refs/tags endpoint ignores per_page/page and returns every ref
+        in one response. list_tags must not fan out additional requests when a
+        response is >= 100 items, otherwise it loops forever and gets rate limited.
+        """
+
+        def fake_run_gh_api(endpoint, *, method="GET", payload=None):
+            if fake.call_count > 1:
+                raise RuntimeError(
+                    "fan-out detected: list_tags issued more than one request"
+                )
+            return _fake_refs(163)
+
+        with mock.patch.object(
+            release, "run_gh_api", side_effect=fake_run_gh_api
+        ) as fake:
+            tags = release.list_tags()
+
+        self.assertEqual(fake.call_count, 1)
+        # All 163 matching tags parsed, prefix stripped, non-matching ref dropped.
+        self.assertEqual(len(tags), 163)
+        self.assertIn("0.0.0", tags)
+        self.assertIn("0.162.0", tags)
+        self.assertNotIn("some-other-tag", tags)
+
+    def test_returns_empty_when_api_call_fails(self):
+        """A failed API call must degrade to an empty list, not raise, so callers
+        (get_latest_release_version / determine_version) can fall back cleanly.
+        """
+        with mock.patch.object(
+            release, "run_gh_api", side_effect=release.ReleaseError("boom")
+        ):
+            self.assertEqual(release.list_tags(), [])
+
+    def test_returns_empty_for_non_list_response(self):
+        """When the path matches a single ref the endpoint returns an object, not
+        a list; list_tags must treat that as "no matching tags" rather than crash.
+        """
+        with mock.patch.object(
+            release, "run_gh_api", return_value={"ref": "refs/tags/skillsets-v1.0.0"}
+        ):
+            self.assertEqual(release.list_tags(), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
🤖 Generated with [Nori](https://noriagentic.com/)

- `list_tags()` paged through GitHub's `/git/refs/tags` in a `while True` loop that only exited when a page returned `<100` refs. That endpoint **ignores** `per_page`/`page` and returns every matching ref (163 today) in one response, so the exit condition never fired → infinite loop + GitHub rate-limiting. This is why `--get-latest-stable` and `--publish-release --dry-run` hung forever.
- Replaced the loop with a **single request** (the endpoint returns up to 1000 refs at once). This also resolves the original rate-limiting concern that motivated pagination — it's now one request, the minimum possible fan-out.
- Added a guard that warns to stderr if the response hits the API's 1000-ref cap, so silent truncation can never corrupt version math.
- Added regression tests: the single-request contract (asserts exactly one API call, parsing/filtering correct) plus the empty-on-error and non-list-response fallbacks.

## Test Plan
- [x] `python3 -m unittest scripts.test_create_skillsets_release` (3 tests pass)
- [x] `./scripts/create_skillsets_release.py --get-latest-stable` → `0.26.0` instantly (previously hung)
- [x] `./scripts/create_skillsets_release.py --publish-release --dry-run` → `0.27.0` instantly (previously hung)
- [x] `ruff check` + `black --check` clean

Share Nori with your team: https://www.npmjs.com/package/nori-skillsets