### PR TITLE
fix(release): list tags via git ls-remote to remove the 1000-tag cliff

### DIFF
--- a/scripts/create_skillsets_release.py
+++ b/scripts/create_skillsets_release.py
@@ -287,35 +287,28 @@ def determine_version(args: argparse.Namespace) -> str:
 def list_tags() -> list[str]:
     """List all tags matching TAG_PREFIX, returning version strings.
 
-    The git/refs/tags endpoint returns up to 1000 matching refs in a single
-    response and ignores per_page/page query parameters. A single request is
-    both correct and necessary: page-based pagination here never terminates
-    (every page returns the full set) and fanning out repeated requests gets
-    us rate limited by GitHub.
+    Uses `git ls-remote` rather than the REST API: it returns every matching
+    tag in a single git-protocol round trip with no pagination, no ref-count
+    cap, and no REST rate-limiting exposure. (The git/refs/tags REST endpoint
+    ignores per_page/page and silently truncates at 1000 refs, so it cannot be
+    paginated correctly.)
     """
-    try:
-        response = run_gh_api(f"/repos/{REPO}/git/refs/tags")
-    except ReleaseError:
+    result = run_git(
+        ["ls-remote", "--tags", "origin", f"refs/tags/{TAG_PREFIX}*"], check=False
+    )
+    if result.returncode != 0:
         return []
-
-    if not isinstance(response, list):
-        return []
-
-    # The endpoint caps at 1000 refs with no Link header, so a full response
-    # means results may be silently truncated and version math would be wrong.
-    if len(response) >= 1000:
-        print(
-            f"WARNING: git/refs/tags returned {len(response)} refs; results may "
-            "be truncated at the API's 1000-ref limit.",
-            file=sys.stderr,
-        )
 
     prefix = f"refs/tags/{TAG_PREFIX}"
-    return [
-        ref["ref"][len(prefix) :]
-        for ref in response
-        if ref.get("ref", "").startswith(prefix)
-    ]
+    tags: list[str] = []
+    for line in result.stdout.splitlines():
+        # Each line is "<sha>\t<ref>". Annotated tags also emit a peeled
+        # "<ref>^{}" line, which we skip to avoid duplicates.
+        _, _, ref = line.partition("\t")
+        if not ref.startswith(prefix) or ref.endswith("^{}"):
+            continue
+        tags.append(ref[len(prefix) :])
+    return tags
 
 
 def get_latest_release_version() -> Optional[str]:

--- a/scripts/test_create_skillsets_release.py
+++ b/scripts/test_create_skillsets_release.py
@@ -3,6 +3,7 @@
 
 import importlib.util
 import os
+import subprocess
 import unittest
 from unittest import mock
 
@@ -15,55 +16,50 @@ release = importlib.util.module_from_spec(_SPEC)
 _SPEC.loader.exec_module(release)
 
 
-def _fake_refs(count: int) -> list[dict]:
-    """Build a list of `count` tag refs as the GitHub git/refs/tags API returns them."""
-    refs = [{"ref": f"refs/tags/{release.TAG_PREFIX}0.{i}.0"} for i in range(count)]
-    # A non-matching ref must be filtered out.
-    refs.append({"ref": "refs/tags/some-other-tag"})
-    return refs
+def _ls_remote_output(versions: list[str]) -> str:
+    """Render `git ls-remote --tags` output for the given matching versions.
+
+    Annotated tags emit both the tag ref and a peeled "^{}" ref; list_tags
+    must dedupe those. A non-matching ref is included to exercise filtering.
+    """
+    lines = []
+    for v in versions:
+        sha = "0" * 40
+        lines.append(f"{sha}\trefs/tags/{release.TAG_PREFIX}{v}")
+        lines.append(f"{sha}\trefs/tags/{release.TAG_PREFIX}{v}^{{}}")
+    lines.append(f"{'1' * 40}\trefs/tags/some-other-tag")
+    return "\n".join(lines) + "\n"
+
+
+def _completed(stdout: str, returncode: int = 0) -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(
+        args=["git"], returncode=returncode, stdout=stdout, stderr=""
+    )
 
 
 class ListTagsTest(unittest.TestCase):
-    def test_makes_a_single_api_request_for_a_full_response(self):
-        """The git/refs/tags endpoint ignores per_page/page and returns every ref
-        in one response. list_tags must not fan out additional requests when a
-        response is >= 100 items, otherwise it loops forever and gets rate limited.
+    def test_parses_remote_tags_and_dedupes_peeled_refs(self):
+        """list_tags reads tags from the remote in a single call, strips the
+        prefix, drops non-matching refs, and does not double-count the peeled
+        "^{}" refs that annotated tags produce.
         """
-
-        def fake_run_gh_api(endpoint, *, method="GET", payload=None):
-            if fake.call_count > 1:
-                raise RuntimeError(
-                    "fan-out detected: list_tags issued more than one request"
-                )
-            return _fake_refs(163)
-
         with mock.patch.object(
-            release, "run_gh_api", side_effect=fake_run_gh_api
-        ) as fake:
+            release,
+            "run_git",
+            return_value=_completed(_ls_remote_output(["0.1.0", "0.2.0", "0.26.0"])),
+        ) as run_git:
             tags = release.list_tags()
 
-        self.assertEqual(fake.call_count, 1)
-        # All 163 matching tags parsed, prefix stripped, non-matching ref dropped.
-        self.assertEqual(len(tags), 163)
-        self.assertIn("0.0.0", tags)
-        self.assertIn("0.162.0", tags)
+        self.assertEqual(run_git.call_count, 1)
+        self.assertEqual(sorted(tags), ["0.1.0", "0.2.0", "0.26.0"])
         self.assertNotIn("some-other-tag", tags)
 
-    def test_returns_empty_when_api_call_fails(self):
-        """A failed API call must degrade to an empty list, not raise, so callers
+    def test_returns_empty_when_remote_query_fails(self):
+        """A failed remote query degrades to an empty list so callers
         (get_latest_release_version / determine_version) can fall back cleanly.
         """
         with mock.patch.object(
-            release, "run_gh_api", side_effect=release.ReleaseError("boom")
-        ):
-            self.assertEqual(release.list_tags(), [])
-
-    def test_returns_empty_for_non_list_response(self):
-        """When the path matches a single ref the endpoint returns an object, not
-        a list; list_tags must treat that as "no matching tags" rather than crash.
-        """
-        with mock.patch.object(
-            release, "run_gh_api", return_value={"ref": "refs/tags/skillsets-v1.0.0"}
+            release, "run_git", return_value=_completed("", returncode=128)
         ):
             self.assertEqual(release.list_tags(), [])
 


### PR DESCRIPTION
## Summary
🤖 Generated with [Nori](https://noriagentic.com/)

Fixup on #521. That PR replaced the infinite pagination loop with a single `git/refs/tags` REST call — correct today, but that endpoint emits **no `Link` header** and silently truncates at **1000 refs**. Past 1000 tags it would return a truncated set and compute the wrong "latest" version, guarded only by a stderr warning (easily missed in CI). A deferred timebomb.

- Switch `list_tags()` to **`git ls-remote --tags origin`**: one git-protocol round trip, **no pagination, no ref-count cap, and zero REST rate-limit exposure** — which was the original reason pagination was added in the first place.
- Filter the peeled `^{}` refs that annotated tags emit so versions aren't double-counted.
- Drop the now-unneeded 1000-ref truncation warning.

## Test Plan
- [x] `python3 -m unittest scripts.test_create_skillsets_release` — 2 tests pass (remote-tag parsing + peeled-ref dedup; empty-on-failure fallback)
- [x] `./scripts/create_skillsets_release.py --get-latest-stable` → `0.26.0`
- [x] `./scripts/create_skillsets_release.py --publish-release --dry-run` → `0.27.0`
- [x] `./scripts/create_skillsets_release.py --get-next-version` → `0.26.0-next.6`
- [x] `ruff check` + `black --check` clean

Share Nori with your team: https://www.npmjs.com/package/nori-skillsets