### PR TITLE
Pre-flight: make public/ correct across all registrar commands + tests

### DIFF
--- a/src/cli/commands/external/external.ts
+++ b/src/cli/commands/external/external.ts
@@ -32,6 +32,7 @@ import {
 } from "@/norijson/nori.js";
 import { getNoriSkillsetsDir } from "@/norijson/skillset.js";
 import { resolveInstallDir } from "@/utils/path.js";
+import { localSkillsetName } from "@/utils/url.js";
 
 import type { CommandStatus } from "@/cli/commands/commandStatus.js";
 import type { Command } from "commander";
@@ -383,12 +384,13 @@ export const externalMain = async (args: {
     targetSkillset = newSkillset;
     log.success(`Created new skillset "${newSkillset}"`);
   } else if (skillset != null) {
-    const skillsetDir = path.join(skillsetsDir, skillset);
+    const resolvedName = localSkillsetName({ name: skillset });
+    const skillsetDir = path.join(skillsetsDir, resolvedName);
     await ensureNoriJson({ skillsetDir: skillsetDir });
     const skillsetMarker = path.join(skillsetDir, "nori.json");
     try {
       await fs.access(skillsetMarker);
-      targetSkillset = skillset;
+      targetSkillset = resolvedName;
     } catch {
       log.error(
         `Skillset "${skillset}" not found at: ${skillsetDir}\n\nMake sure the skillset exists and contains a nori.json file.`,
@@ -402,10 +404,11 @@ export const externalMain = async (args: {
   } else if (config != null) {
     const activeSkillset = getActiveSkillset({ config });
     if (activeSkillset != null) {
-      const skillsetDir = path.join(skillsetsDir, activeSkillset);
+      const resolvedName = localSkillsetName({ name: activeSkillset });
+      const skillsetDir = path.join(skillsetsDir, resolvedName);
       try {
         await fs.access(skillsetDir);
-        targetSkillset = activeSkillset;
+        targetSkillset = resolvedName;
       } catch {
         // Profile directory doesn't exist - skip manifest update
       }

--- a/src/cli/commands/registry-download/registryDownload.test.ts
+++ b/src/cli/commands/registry-download/registryDownload.test.ts
@@ -2003,7 +2003,57 @@ describe("registry-download", () => {
       expect(stats.isDirectory()).toBe(true);
     });
 
-    it("should download public namespace package to flat directory", async () => {
+    it("should keep the org namespace in the reinstall hint when an org package exists without .nori-version", async () => {
+      // Existing org profile installed manually (no .nori-version) at the
+      // nested path profiles/myorg/test-profile.
+      const existingProfileDir = path.join(
+        skillsetsDir,
+        "myorg",
+        "test-profile",
+      );
+      await fs.mkdir(existingProfileDir, { recursive: true });
+      await fs.writeFile(
+        path.join(existingProfileDir, "nori.json"),
+        JSON.stringify({ name: "test-profile", version: "1.0.0" }),
+      );
+
+      vi.mocked(loadConfig).mockResolvedValue({
+        installDir: testDir,
+        auth: {
+          username: "test@example.com",
+          organizationUrl: "https://tilework.tilework.tech",
+          refreshToken: "test-refresh-token",
+          organizations: ["myorg"],
+        },
+      });
+
+      vi.mocked(getRegistryAuthToken).mockResolvedValue("mock-auth-token");
+
+      vi.mocked(registrarApi.getPackument).mockResolvedValue({
+        name: "test-profile",
+        "dist-tags": { latest: "1.0.0" },
+        versions: { "1.0.0": { name: "test-profile", version: "1.0.0" } },
+      });
+
+      const result = await registryDownloadMain({
+        packageSpec: "myorg/test-profile",
+        cwd: testDir,
+      });
+
+      expect(result.success).toBe(false);
+      expect(registrarApi.downloadTarball).not.toHaveBeenCalled();
+
+      // The error headline and reinstall command hint must preserve the org
+      // namespace, not collapse to the bare package name. (The install path
+      // trivially contains "myorg/test-profile", so assert on the quoted name
+      // and the download command specifically.)
+      const allOutput = getAllClackOutput();
+      expect(allOutput).toContain('Skillset "myorg/test-profile"');
+      expect(allOutput).toContain("download myorg/test-profile");
+      expect(allOutput).not.toContain('Skillset "test-profile"');
+    });
+
+    it("should download bare (default public) package to flat directory", async () => {
       vi.mocked(loadConfig).mockResolvedValue({
         installDir: testDir,
         auth: {
@@ -2046,6 +2096,50 @@ describe("registry-download", () => {
       const skillsetDir = path.join(skillsetsDir, "my-profile");
       const stats = await fs.stat(skillsetDir);
       expect(stats.isDirectory()).toBe(true);
+    });
+
+    it("should treat an explicit public/ prefix identically to a bare public package", async () => {
+      // No auth configured — the public registry never requires it.
+      vi.mocked(loadConfig).mockResolvedValue({
+        installDir: testDir,
+      });
+
+      vi.mocked(registrarApi.getPackument).mockResolvedValue({
+        name: "my-profile",
+        "dist-tags": { latest: "1.0.0" },
+        versions: { "1.0.0": { name: "my-profile", version: "1.0.0" } },
+      });
+
+      const mockTarball = await createMockTarball();
+      vi.mocked(registrarApi.downloadTarball).mockResolvedValue(mockTarball);
+
+      await registryDownloadMain({
+        packageSpec: "public/my-profile",
+        cwd: testDir,
+      });
+
+      // Only the public REGISTRAR_URL is searched, with no auth token.
+      expect(registrarApi.getPackument).toHaveBeenCalledTimes(1);
+      expect(registrarApi.getPackument).toHaveBeenCalledWith({
+        packageName: "my-profile",
+        registryUrl: REGISTRAR_URL,
+      });
+      expect(getRegistryAuthToken).not.toHaveBeenCalled();
+
+      // The tarball is fetched from the public registry with no auth token.
+      expect(registrarApi.downloadTarball).toHaveBeenCalledWith({
+        packageName: "my-profile",
+        version: undefined,
+        registryUrl: REGISTRAR_URL,
+        authToken: undefined,
+      });
+
+      // The skillset lands flat at profiles/my-profile, not profiles/public/my-profile.
+      const flatDir = path.join(skillsetsDir, "my-profile");
+      expect((await fs.stat(flatDir)).isDirectory()).toBe(true);
+      await expect(
+        fs.access(path.join(skillsetsDir, "public", "my-profile")),
+      ).rejects.toThrow();
     });
 
     it("should handle namespaced package with version", async () => {

--- a/src/cli/commands/registry-download/registryDownload.ts
+++ b/src/cli/commands/registry-download/registryDownload.ts
@@ -38,6 +38,7 @@ import { resolveInstallDir } from "@/utils/path.js";
 import {
   parseNamespacedPackage,
   buildOrganizationRegistryUrl,
+  namespacedName,
 } from "@/utils/url.js";
 
 import type { CommandStatus } from "@/cli/commands/commandStatus.js";
@@ -606,7 +607,7 @@ const searchSpecificRegistry = async (args: {
 /**
  * Format the list of available versions for a package
  * @param args - The format parameters
- * @param args.packageName - The package name
+ * @param args.displayName - The namespaced display name (e.g. "myorg/my-profile")
  * @param args.packument - The packument containing version information
  * @param args.registryUrl - The registry URL
  * @param args.cliName - The CLI name for command hints
@@ -614,12 +615,12 @@ const searchSpecificRegistry = async (args: {
  * @returns Formatted version list message
  */
 const formatVersionList = (args: {
-  packageName: string;
+  displayName: string;
   packument: Packument;
   registryUrl: string;
   cliName?: CliName | null;
 }): string => {
-  const { packageName, packument, registryUrl, cliName } = args;
+  const { displayName, packument, registryUrl, cliName } = args;
   const commandNames = getCommandNames({ cliName });
   const distTags = packument["dist-tags"];
   const versions = Object.keys(packument.versions);
@@ -633,7 +634,7 @@ const formatVersionList = (args: {
   });
 
   const lines = [
-    `Available versions of "${packageName}" from ${registryUrl}:\n`,
+    `Available versions of "${displayName}" from ${registryUrl}:\n`,
     "Dist-tags:",
   ];
 
@@ -659,7 +660,7 @@ const formatVersionList = (args: {
 
   const cliPrefix = cliName ?? "nori-skillsets";
   lines.push(
-    `\nTo download a specific version:\n  ${cliPrefix} ${commandNames.download} ${packageName}@<version>`,
+    `\nTo download a specific version:\n  ${cliPrefix} ${commandNames.download} ${displayName}@<version>`,
   );
 
   return lines.join("\n");
@@ -752,8 +753,7 @@ export const registryDownloadMain = async (args: {
   }
   const { orgId, packageName, version } = parsed;
   // Display name includes org prefix for namespaced packages (e.g., "myorg/my-profile")
-  const profileDisplayName =
-    orgId === "public" ? packageName : `${orgId}/${packageName}`;
+  const profileDisplayName = namespacedName({ orgId, packageName });
 
   // Resolve install directory from config and auto-init if needed
   const config = await loadConfig();
@@ -786,10 +786,10 @@ export const registryDownloadMain = async (args: {
 
   const skillsetsDir = getNoriSkillsetsDir();
   // For namespaced packages, the skillset is in a nested directory (e.g., profiles/myorg/my-profile)
-  const targetDir =
-    orgId === "public"
-      ? path.join(skillsetsDir, packageName)
-      : path.join(skillsetsDir, orgId, packageName);
+  const targetDir = path.join(
+    skillsetsDir,
+    ...namespacedName({ orgId, packageName }).split("/"),
+  );
 
   // Check if skillset already exists and get its version info
   let existingVersionInfo: VersionInfo | null = null;
@@ -952,7 +952,7 @@ export const registryDownloadMain = async (args: {
           return {
             status: "list-versions",
             formattedVersionList: formatVersionList({
-              packageName,
+              displayName: profileDisplayName,
               packument: foundRegistry.packument,
               registryUrl: foundRegistry.registryUrl,
               cliName,
@@ -1037,8 +1037,8 @@ export const registryDownloadMain = async (args: {
         if (profileExists && existingVersionInfo == null) {
           return {
             status: "error",
-            error: `Skillset "${packageName}" already exists at:\n${targetDir}\n\nThis skillset has no version information (.nori-version file).`,
-            hint: `To reinstall:\n  rm -rf "${targetDir}"\n  ${cliPrefix} ${commandNames.download} ${packageName}`,
+            error: `Skillset "${profileDisplayName}" already exists at:\n${targetDir}\n\nThis skillset has no version information (.nori-version file).`,
+            hint: `To reinstall:\n  rm -rf "${targetDir}"\n  ${cliPrefix} ${commandNames.download} ${profileDisplayName}`,
           };
         }
 

--- a/src/cli/commands/registry-upload/registryUpload.ts
+++ b/src/cli/commands/registry-upload/registryUpload.ts
@@ -53,6 +53,7 @@ import {
   parseNamespacedPackage,
   buildOrganizationRegistryUrl,
   extractOrgId,
+  namespacedName,
 } from "@/utils/url.js";
 
 import type { CommandStatus } from "@/cli/commands/commandStatus.js";
@@ -1056,8 +1057,7 @@ export const registryUploadMain = async (args: {
   }
 
   const { orgId, packageName, version } = parsed;
-  const profileDisplayName =
-    orgId === "public" ? packageName : `${orgId}/${packageName}`;
+  const profileDisplayName = namespacedName({ orgId, packageName });
 
   const VALID_RESOLVE_ACTIONS: ReadonlyArray<string> = [
     "updateVersion",
@@ -1323,10 +1323,10 @@ export const registryUploadMain = async (args: {
 
   // Check skillset exists locally
   const skillsetsDir = getNoriSkillsetsDir();
-  const skillsetDir =
-    orgId === "public"
-      ? path.join(skillsetsDir, packageName)
-      : path.join(skillsetsDir, orgId, packageName);
+  const skillsetDir = path.join(
+    skillsetsDir,
+    ...namespacedName({ orgId, packageName }).split("/"),
+  );
 
   try {
     await fs.access(skillsetDir);

--- a/src/cli/commands/skill-download/skillDownload.test.ts
+++ b/src/cli/commands/skill-download/skillDownload.test.ts
@@ -533,6 +533,47 @@ describe("skill-download", () => {
       expect(stats.isDirectory()).toBe(true);
     });
 
+    it("should treat an explicit public/ prefix identically to a bare public skill", async () => {
+      vi.mocked(loadConfig).mockResolvedValue({
+        installDir: testDir,
+      });
+
+      vi.mocked(registrarApi.getSkillPackument).mockResolvedValue({
+        name: "test-skill",
+        "dist-tags": { latest: "1.0.0" },
+        versions: { "1.0.0": { name: "test-skill", version: "1.0.0" } },
+      });
+
+      const mockTarball = await createMockSkillTarball();
+      vi.mocked(registrarApi.downloadSkillTarball).mockResolvedValue(
+        mockTarball,
+      );
+
+      await skillDownloadMain({
+        skillSpec: "public/test-skill",
+        cwd: testDir,
+      });
+
+      // Only the public REGISTRAR_URL is searched, with no auth token.
+      expect(registrarApi.getSkillPackument).toHaveBeenCalledTimes(1);
+      expect(registrarApi.getSkillPackument).toHaveBeenCalledWith({
+        skillName: "test-skill",
+        registryUrl: REGISTRAR_URL,
+      });
+
+      expect(registrarApi.downloadSkillTarball).toHaveBeenCalledWith({
+        skillName: "test-skill",
+        version: undefined,
+        registryUrl: REGISTRAR_URL,
+        authToken: undefined,
+      });
+
+      // Installed under the bare skill name, not skills/public/test-skill.
+      const skillDir = path.join(skillsDir, "test-skill");
+      expect((await fs.stat(skillDir)).isDirectory()).toBe(true);
+      await expect(fs.access(path.join(skillsDir, "public"))).rejects.toThrow();
+    });
+
     it("should error when namespaced skill downloaded without auth", async () => {
       // Mock config without unified auth (no auth.organizations)
       vi.mocked(loadConfig).mockResolvedValue({
@@ -1108,6 +1149,47 @@ describe("--skillset option and manifest updates", () => {
     const skillsJsonContent = await fs.readFile(skillsJsonPath, "utf-8");
     const skillsJson = JSON.parse(skillsJsonContent);
     expect(skillsJson["test-skill"]).toBe("*");
+  });
+
+  it("should resolve a redundant public/ prefixed --skillset to the flat skillset", async () => {
+    vi.mocked(loadConfig).mockResolvedValue({
+      installDir: testDir,
+
+      activeSkillset: "other-profile",
+    });
+
+    vi.mocked(registrarApi.getSkillPackument).mockResolvedValue({
+      name: "test-skill",
+      "dist-tags": { latest: "1.0.0" },
+      versions: { "1.0.0": { name: "test-skill", version: "1.0.0" } },
+    });
+
+    const mockTarball = await createMockSkillTarball();
+    vi.mocked(registrarApi.downloadSkillTarball).mockResolvedValue(mockTarball);
+
+    const result = await skillDownloadMain({
+      skillSpec: "test-skill",
+      cwd: testDir,
+      skillset: "public/test-profile",
+    });
+
+    expect(result.success).toBe(true);
+
+    // Verify skill was added to the flat (public) profile's skills.json,
+    // not a nonexistent profiles/public/test-profile directory.
+    const skillsJsonPath = path.join(
+      skillsetsDir,
+      "test-profile",
+      "skills.json",
+    );
+    const skillsJsonContent = await fs.readFile(skillsJsonPath, "utf-8");
+    const skillsJson = JSON.parse(skillsJsonContent);
+    expect(skillsJson["test-skill"]).toBe("*");
+
+    // The redundant public/ directory must not have been created.
+    await expect(
+      fs.access(path.join(skillsetsDir, "public", "test-profile")),
+    ).rejects.toThrow();
   });
 
   it("should add skill to active profile's skills.json when --skillset not specified", async () => {

--- a/src/cli/commands/skill-download/skillDownload.ts
+++ b/src/cli/commands/skill-download/skillDownload.ts
@@ -37,6 +37,7 @@ import { resolveInstallDir } from "@/utils/path.js";
 import {
   parseNamespacedPackage,
   buildOrganizationRegistryUrl,
+  localSkillsetName,
 } from "@/utils/url.js";
 
 import type { Packument } from "@/api/registrar.js";
@@ -420,12 +421,13 @@ export const skillDownloadMain = async (args: {
 
   if (skillset != null) {
     // User specified a skillset - verify it exists
-    const skillsetDir = path.join(skillsetsDir, skillset);
+    const resolvedName = localSkillsetName({ name: skillset });
+    const skillsetDir = path.join(skillsetsDir, resolvedName);
     await ensureNoriJson({ skillsetDir: skillsetDir });
     const skillsetMarker = path.join(skillsetDir, "nori.json");
     try {
       await fs.access(skillsetMarker);
-      targetSkillset = skillset;
+      targetSkillset = resolvedName;
     } catch {
       log.error(
         `Skillset "${skillset}" not found at: ${skillsetDir}\n\nMake sure the skillset exists and contains a nori.json file.`,
@@ -441,10 +443,11 @@ export const skillDownloadMain = async (args: {
     const activeSkillset = getActiveSkillset({ config });
     if (activeSkillset != null) {
       // Verify skillset directory exists
-      const skillsetDir = path.join(skillsetsDir, activeSkillset);
+      const resolvedName = localSkillsetName({ name: activeSkillset });
+      const skillsetDir = path.join(skillsetsDir, resolvedName);
       try {
         await fs.access(skillsetDir);
-        targetSkillset = activeSkillset;
+        targetSkillset = resolvedName;
       } catch {
         // Skillset directory doesn't exist - skip manifest update
       }

--- a/src/cli/commands/skill-upload/skillUpload.test.ts
+++ b/src/cli/commands/skill-upload/skillUpload.test.ts
@@ -329,6 +329,37 @@ describe("skill-upload", () => {
       expect(registrarApi.uploadSkill).toHaveBeenCalledTimes(1);
     });
 
+    it("resolves the source skill from a redundant public/ prefixed --skillset", async () => {
+      await createLocalSkill({
+        skillsetName: "flat-profile",
+        skillName: "flat-skill",
+      });
+
+      vi.mocked(loadConfig).mockResolvedValue(
+        authenticatedConfig("my-profile") as never,
+      );
+
+      vi.mocked(registrarApi.getSkillPackument).mockRejectedValue(
+        Object.assign(new Error("Not found"), { statusCode: 404 }),
+      );
+      vi.mocked(registrarApi.uploadSkill).mockResolvedValue({
+        name: "flat-skill",
+        version: "1.0.0",
+        tarballSha: "sha",
+        createdAt: "2026-04-16T00:00:00.000Z",
+      } as never);
+
+      const result = await skillUploadMain({
+        skillSpec: "flat-skill",
+        skillset: "public/flat-profile",
+      });
+
+      // Upload only fires if `public/flat-profile` resolved to the flat
+      // `flat-profile` and the source skill was found there.
+      expect(result.success).toBe(true);
+      expect(registrarApi.uploadSkill).toHaveBeenCalledTimes(1);
+    });
+
     it("treats identical remote content as already up to date (no upload)", async () => {
       const skillMd = `---\nname: stable-skill\ndescription: d\n---\n\n# stable-skill\nSame content.\n`;
       await createLocalSkill({

--- a/src/cli/commands/skill-upload/skillUpload.ts
+++ b/src/cli/commands/skill-upload/skillUpload.ts
@@ -42,6 +42,7 @@ import {
   parseNamespacedPackage,
   buildOrganizationRegistryUrl,
   extractOrgId,
+  localSkillsetName,
 } from "@/utils/url.js";
 
 import type { CommandStatus } from "@/cli/commands/commandStatus.js";
@@ -377,8 +378,11 @@ export const skillUploadMain = async (args: {
     };
   }
 
+  // Normalize a redundant `public/` prefix to the flat on-disk name.
+  const resolvedSource = localSkillsetName({ name: sourceSkillset });
+
   const skillsetsDir = getNoriSkillsetsDir();
-  const skillDir = path.join(skillsetsDir, sourceSkillset, "skills", skillName);
+  const skillDir = path.join(skillsetsDir, resolvedSource, "skills", skillName);
 
   try {
     await fs.access(skillDir);

--- a/src/cli/commands/subagent-download/subagentDownload.test.ts
+++ b/src/cli/commands/subagent-download/subagentDownload.test.ts
@@ -276,6 +276,64 @@ describe("subagent-download", () => {
       expect(versionInfo.registryUrl).toBe(REGISTRAR_URL);
     });
 
+    it("should download public/ prefixed subagent from the public registry and flatten to the bare name", async () => {
+      vi.mocked(loadConfig).mockResolvedValue({
+        installDir: testDir,
+      });
+
+      vi.mocked(registrarApi.getSubagentPackument).mockResolvedValue({
+        name: "test-subagent",
+        "dist-tags": { latest: "1.0.0" },
+        versions: {
+          "1.0.0": { name: "test-subagent", version: "1.0.0" },
+        },
+      });
+
+      const mockTarball = await createMockSubagentTarball();
+      vi.mocked(registrarApi.downloadSubagentTarball).mockResolvedValue(
+        mockTarball,
+      );
+
+      await subagentDownloadMain({
+        subagentSpec: "public/test-subagent",
+        cwd: testDir,
+      });
+
+      // Public namespace hits the public REGISTRAR_URL with no auth token.
+      expect(registrarApi.downloadSubagentTarball).toHaveBeenCalledWith({
+        subagentName: "test-subagent",
+        version: undefined,
+        registryUrl: REGISTRAR_URL,
+        authToken: undefined,
+      });
+
+      // The install flattens to the bare name, not agents/public/test-subagent.md.
+      const agentFile = path.join(agentsDir, "test-subagent.md");
+      await expect(fs.access(agentFile)).resolves.toBeUndefined();
+      await expect(fs.access(path.join(agentsDir, "public"))).rejects.toThrow();
+    });
+
+    it("should error when a namespaced subagent is combined with an explicit --registry", async () => {
+      vi.mocked(loadConfig).mockResolvedValue({
+        installDir: testDir,
+      });
+
+      const result = await subagentDownloadMain({
+        subagentSpec: "myorg/my-subagent",
+        cwd: testDir,
+        registryUrl: "https://example.noriskillsets.dev",
+      });
+
+      expect(result.success).toBe(false);
+      const allErrorOutput = getClackErrorOutput();
+      expect(allErrorOutput).toMatch(
+        /namespace.*registry|registry.*namespace|cannot.*both/i,
+      );
+
+      // No download should have been attempted.
+      expect(registrarApi.downloadSubagentTarball).not.toHaveBeenCalled();
+    });
+
     it("should handle version specification", async () => {
       vi.mocked(loadConfig).mockResolvedValue({
         installDir: testDir,
@@ -557,6 +615,55 @@ describe("subagent-download", () => {
         "existing-sub": "*",
         "new-sub": "*",
       });
+    });
+
+    it("should resolve a redundant public/ prefixed --skillset to the flat skillset", async () => {
+      const skillsetDir = path.join(skillsetsDir, "flat-profile");
+      await fs.mkdir(skillsetDir, { recursive: true });
+      await fs.writeFile(
+        path.join(skillsetDir, "nori.json"),
+        JSON.stringify({ name: "flat-profile", version: "1.0.0" }),
+      );
+
+      vi.mocked(loadConfig).mockResolvedValue({
+        installDir: testDir,
+        activeSkillset: "other-profile",
+      });
+
+      vi.mocked(registrarApi.getSubagentPackument).mockResolvedValue({
+        name: "downloaded-sub",
+        "dist-tags": { latest: "1.0.0" },
+        versions: { "1.0.0": { name: "downloaded-sub", version: "1.0.0" } },
+      });
+
+      const mockTarball = await createMockSubagentTarball();
+      vi.mocked(registrarApi.downloadSubagentTarball).mockResolvedValue(
+        mockTarball,
+      );
+
+      const result = await subagentDownloadMain({
+        subagentSpec: "downloaded-sub",
+        cwd: testDir,
+        skillset: "public/flat-profile",
+      });
+
+      expect(result.success).toBe(true);
+
+      // Dependency landed in the flat profile's nori.json, proving resolution.
+      const noriJson = JSON.parse(
+        await fs.readFile(path.join(skillsetDir, "nori.json"), "utf-8"),
+      );
+      expect(noriJson.dependencies?.subagents?.["downloaded-sub"]).toBe("*");
+
+      // The subagent extracted into the flat profile, not profiles/public/...
+      await expect(
+        fs.access(
+          path.join(skillsetDir, "subagents", "downloaded-sub", "SUBAGENT.md"),
+        ),
+      ).resolves.toBeUndefined();
+      await expect(
+        fs.access(path.join(skillsetsDir, "public", "flat-profile")),
+      ).rejects.toThrow();
     });
   });
 

--- a/src/cli/commands/subagent-download/subagentDownload.ts
+++ b/src/cli/commands/subagent-download/subagentDownload.ts
@@ -41,6 +41,7 @@ import { resolveInstallDir } from "@/utils/path.js";
 import {
   parseNamespacedPackage,
   buildOrganizationRegistryUrl,
+  localSkillsetName,
 } from "@/utils/url.js";
 
 import type { Packument } from "@/api/registrar.js";
@@ -335,12 +336,13 @@ export const subagentDownloadMain = async (args: {
   const skillsetsDir = getNoriSkillsetsDir();
 
   if (skillset != null) {
-    const skillsetDir = path.join(skillsetsDir, skillset);
+    const resolvedName = localSkillsetName({ name: skillset });
+    const skillsetDir = path.join(skillsetsDir, resolvedName);
     await ensureNoriJson({ skillsetDir });
     const skillsetMarker = path.join(skillsetDir, "nori.json");
     try {
       await fs.access(skillsetMarker);
-      targetSkillset = skillset;
+      targetSkillset = resolvedName;
     } catch {
       log.error(
         `Skillset "${skillset}" not found at: ${skillsetDir}\n\nMake sure the skillset exists and contains a nori.json file.`,
@@ -354,10 +356,11 @@ export const subagentDownloadMain = async (args: {
   } else if (config != null) {
     const activeSkillset = getActiveSkillset({ config });
     if (activeSkillset != null) {
-      const skillsetDir = path.join(skillsetsDir, activeSkillset);
+      const resolvedName = localSkillsetName({ name: activeSkillset });
+      const skillsetDir = path.join(skillsetsDir, resolvedName);
       try {
         await fs.access(skillsetDir);
-        targetSkillset = activeSkillset;
+        targetSkillset = resolvedName;
       } catch {
         // Skillset directory doesn't exist - skip
       }

--- a/src/utils/url.test.ts
+++ b/src/utils/url.test.ts
@@ -10,6 +10,7 @@ import {
   extractOrgId,
   parseNamespacedPackage,
   namespacedName,
+  localSkillsetName,
 } from "./url";
 
 describe("normalizeUrl", () => {
@@ -318,6 +319,26 @@ describe("namespacedName", () => {
     expect(namespacedName({ orgId: "myorg", packageName: "my-profile" })).toBe(
       "myorg/my-profile",
     );
+  });
+});
+
+describe("localSkillsetName", () => {
+  it("strips a redundant public/ prefix to the flat on-disk name", () => {
+    expect(localSkillsetName({ name: "public/my-profile" })).toBe("my-profile");
+  });
+
+  it("returns a bare name unchanged", () => {
+    expect(localSkillsetName({ name: "my-profile" })).toBe("my-profile");
+  });
+
+  it("preserves the org prefix for org-scoped names", () => {
+    expect(localSkillsetName({ name: "myorg/my-profile" })).toBe(
+      "myorg/my-profile",
+    );
+  });
+
+  it("returns an invalid multi-slash name unchanged", () => {
+    expect(localSkillsetName({ name: "a/b/c" })).toBe("a/b/c");
   });
 });
 

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -288,3 +288,25 @@ export const namespacedName = (args: {
   const { orgId, packageName } = args;
   return orgId === "public" ? packageName : `${orgId}/${packageName}`;
 };
+
+/**
+ * Normalize a local skillset name to its on-disk form, tolerating a redundant
+ * `public/` prefix. Public skillsets are stored flat, so `public/foo` and `foo`
+ * both resolve to `foo`; org names (`myorg/foo`) are returned unchanged. A name
+ * that is not a valid package reference is returned as-is.
+ * @param args - Naming arguments
+ * @param args.name - The skillset name as provided (bare, `public/<name>`, or `<org>/<name>`)
+ *
+ * @returns The on-disk skillset name
+ */
+export const localSkillsetName = (args: { name: string }): string => {
+  const { name } = args;
+  const parsed = parseNamespacedPackage({ packageSpec: name });
+  if (parsed == null) {
+    return name;
+  }
+  return namespacedName({
+    orgId: parsed.orgId,
+    packageName: parsed.packageName,
+  });
+};


### PR DESCRIPTION
## Summary
🤖 Generated with [Nori](https://noriagentic.com/)

Follow-up to #527. Before the upcoming `profiles/public/<name>` layout migration, this audits every registrar command for correct `public/` handling and adds the `public/` test coverage that was missing (the exact blind spot that hid the earlier install bug). **Non-breaking** — bare and org behavior is unchanged.

- **Fix — `--skillset public/<name>` trap:** `skill-download`, `subagent-download`, `skill-upload`, and `external-skill` resolved the target/source skillset by raw `path.join`, so a `public/` prefix pointed at a nonexistent nested dir and failed "not found". New `localSkillsetName()` normalizes a redundant `public/` to the flat on-disk name (org/bare unchanged).
- **Fix — dropped org namespace in `download` hints:** the reinstall and version-list hints printed the bare name for org packages, suggesting a command that resolves to the wrong package. Now use the namespaced display name.
- **Cleanup:** route `registry-download`/`registry-upload` flat-vs-nested display+path derivation through `namespacedName` (single seam; behavior-identical) so the install-class bug can't silently return.
- **Tests:** add `public/` coverage to download / skill-download / subagent-download (flat resolution, version strip, asserting no stray `profiles/public/` is created), a subagent conflict-guard test, and the org-namespace hint test.

## Verification
- [x] `npm test` — 2151 passed, 2 todo (137 files)
- [x] `npm run lint` + `format` clean (eslint, tsc, prettier)
- [x] E2E vs production registry: `download-skill public/x --skillset public/sessions-platform` now resolves to the flat skillset (was "not found"); no `profiles/public/` created
- [x] Three self-review passes (correctness audit + code review + test-scenario-hygiene); their findings (missed `external` site, dead param, 3 trivially-true assertions) applied

## Next
Separate PR: the actual layout migration (move public skillsets to `profiles/public/<name>` with auto-migrate + dual-read + bare-name deprecation warning + the switch-redownload fix), coordinated with nori-sessions.

Share Nori with your team: https://www.npmjs.com/package/nori-skillsets