### PR TITLE
fix(cli): drop broken upload-skill --version flag; use skill@version

### DIFF
--- a/src/cli/commands/noriSkillsetsCommands.test.ts
+++ b/src/cli/commands/noriSkillsetsCommands.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Tests for nori-skillsets command registration.
+ */
+
+import { Command } from "commander";
+import { describe, it, expect } from "vitest";
+
+import { registerNoriSkillsetsUploadSkillCommand } from "./noriSkillsetsCommands.js";
+
+describe("registerNoriSkillsetsUploadSkillCommand", () => {
+  const buildUploadSkillCommand = (): Command => {
+    const program = new Command();
+    // Mirror the real CLI, which registers a program-level version flag.
+    program.version("9.9.9");
+    registerNoriSkillsetsUploadSkillCommand({ program });
+    const command = program.commands.find((c) => c.name() === "upload-skill");
+    if (command == null) {
+      throw new Error("upload-skill command was not registered");
+    }
+    return command;
+  };
+
+  it("does not define a --version option (it collides with the program's global --version; version is set via skill@version)", () => {
+    const command = buildUploadSkillCommand();
+    const longFlags = command.options.map((option) => option.long);
+    expect(longFlags).not.toContain("--version");
+  });
+
+  it("still registers its real options", () => {
+    const command = buildUploadSkillCommand();
+    const longFlags = command.options.map((option) => option.long);
+    expect(longFlags).toEqual(
+      expect.arrayContaining([
+        "--skillset",
+        "--registry",
+        "--public",
+        "--description",
+      ]),
+    );
+  });
+});

--- a/src/cli/commands/noriSkillsetsCommands.ts
+++ b/src/cli/commands/noriSkillsetsCommands.ts
@@ -602,7 +602,6 @@ export const registerNoriSkillsetsUploadSkillCommand = (args: {
     )
     .option("--registry <url>", "Upload to a specific registry URL")
     .option("--public", "Publish to the public registry (noriskillsets.dev)")
-    .option("--version <version>", "Explicit version to publish")
     .option("--description <text>", "Description for this version")
     .action(
       async (
@@ -611,7 +610,6 @@ export const registerNoriSkillsetsUploadSkillCommand = (args: {
           skillset?: string;
           registry?: string;
           public?: boolean;
-          version?: string;
           description?: string;
         },
       ) => {
@@ -629,7 +627,6 @@ export const registerNoriSkillsetsUploadSkillCommand = (args: {
               skillset: options.skillset || null,
               registryUrl: options.registry || null,
               publicRegistry: options.public || null,
-              version: options.version || null,
               description: options.description || null,
               cliName: "nori-skillsets",
               nonInteractive: globalOpts.nonInteractive || null,

--- a/src/cli/commands/skill-upload/skillUpload.test.ts
+++ b/src/cli/commands/skill-upload/skillUpload.test.ts
@@ -300,6 +300,37 @@ describe("skill-upload", () => {
       expect(result.message).toContain("1.0.0");
     });
 
+    it("publishes the version supplied via the skill@version spec", async () => {
+      await createLocalSkill({
+        skillsetName: "my-profile",
+        skillName: "my-skill",
+      });
+
+      vi.mocked(loadConfig).mockResolvedValue(
+        authenticatedConfig("my-profile") as never,
+      );
+
+      // Remote skill does not exist (404)
+      vi.mocked(registrarApi.getSkillPackument).mockRejectedValue(
+        Object.assign(new Error("Not found"), { statusCode: 404 }),
+      );
+
+      vi.mocked(registrarApi.uploadSkill).mockResolvedValue({
+        name: "my-skill",
+        version: "2.0.0",
+        tarballSha: "sha512-xyz",
+        createdAt: "2026-04-16T00:00:00.000Z",
+      } as never);
+
+      const result = await skillUploadMain({ skillSpec: "my-skill@2.0.0" });
+
+      expect(result.success).toBe(true);
+      expect(registrarApi.uploadSkill).toHaveBeenCalledTimes(1);
+      const uploadCall = vi.mocked(registrarApi.uploadSkill).mock.calls[0][0];
+      expect(uploadCall.skillName).toBe("my-skill");
+      expect(uploadCall.version).toBe("2.0.0");
+    });
+
     it("resolves skill from --skillset flag instead of active skillset", async () => {
       await createLocalSkill({
         skillsetName: "other-profile",

--- a/src/cli/commands/skill-upload/skillUpload.ts
+++ b/src/cli/commands/skill-upload/skillUpload.ts
@@ -1,6 +1,6 @@
 /**
  * CLI command for uploading a single skill package to the Nori registrar.
- * Handles: nori-skillsets upload-skill <skill> [--skillset <name>] [--registry <url>] [--version <ver>] [--description <text>]
+ * Handles: nori-skillsets upload-skill <skill>[@<version>] [--skillset <name>] [--registry <url>] [--description <text>]
  */
 
 import * as fs from "fs/promises";

--- a/src/cli/nori-skillsets.ts
+++ b/src/cli/nori-skillsets.ts
@@ -133,7 +133,7 @@ Examples:
   $ nori-skillsets download-skill my-skill --list-versions
   $ nori-skillsets upload-skill my-skill
   $ nori-skillsets upload-skill my-skill --skillset my-profile
-  $ nori-skillsets upload-skill my-skill --version 1.2.0
+  $ nori-skillsets upload-skill my-skill@1.2.0
   $ nori-skillsets download-subagent my-subagent
   $ nori-skillsets download-subagent my-subagent@1.0.0
   $ nori-skillsets download-subagent my-subagent --list-versions

--- a/src/cli/prompts/flows/skillUpload.ts
+++ b/src/cli/prompts/flows/skillUpload.ts
@@ -125,7 +125,7 @@ export const skillUploadFlow = async (args: {
 
   if (nonInteractive) {
     log.error(
-      `"${skillDisplayName}" has uncommitted local changes vs. registry version ${existing.latestVersion}. Pass --version to upload non-interactively.`,
+      `"${skillDisplayName}" has uncommitted local changes vs. registry version ${existing.latestVersion}. Re-run with an explicit version (e.g. ${skillDisplayName}@<version>) to upload non-interactively.`,
     );
     return null;
   }


### PR DESCRIPTION
## Summary
🤖 Generated with [Nori](https://noriagentic.com/)

`nori-skillsets upload-skill <skill> --version <version>` was a **silent no-op**: it printed the CLI version and exited `0` without uploading.

**Root cause:** the program registers a global `-V, --version` via `.version()`. In commander v14, that global version flag wins over a subcommand's own `--version` option, so `upload-skill foo --version 2.0.0` is resolved as "print the CLI version and exit" before the action ever runs. Confirmed with a minimal commander repro.

**Fix:** remove the redundant, broken `--version` option from `upload-skill` and rely on the already-supported `skill@version` spec — the same pattern the `upload` (skillset) command already uses (`upload amol@2.0.28`). `skillUploadMain` already parses the version from the spec (`effectiveVersion = explicitVersion ?? specVersion`), so there is no capability loss.

Nothing invoked the flag (checked every repo under the org's local checkout + CI docs); its only references were documentation. Since it never worked, no script could depend on its behavior.

## Changes
- Remove `--version` option from the `upload-skill` command registration.
- Update the help example: `upload-skill my-skill --version 1.2.0` → `upload-skill my-skill@1.2.0`.
- Update the non-interactive conflict hint to point at `<skill>@<version>` instead of `--version`.
- Update the command doc-comment.
- Tests: add a registration guard (no `--version` option on `upload-skill`) and a behavioral test that `skill@version` publishes the given version.

## Alternatives considered
- **`.enablePositionalOptions()`** — would let both global and subcommand `--version` coexist, but it breaks existing `nori-skillsets <cmd> -n/--silent` (globals-after-subcommand) usage. Too broad.
- **Rename the flag / change the global version flag** — either leaves the `--version` footgun or breaks the conventional global `nori-skillsets --version`.

Removing the flag and standardizing on `skill@version` is the least-surprising, most consistent option.

## Testing
- `npm run lint` (eslint + prettier + tsc): clean.
- `npm test`: **138 files, 2142 passed**, 0 failed.
- Manual against the built CLI: global `--version` still prints the version; `upload-skill --help` no longer advertises `--version`; `upload-skill <skill>@2.0.0` reaches the action instead of printing the CLI version.